### PR TITLE
Add support for selling to DodoV2 on Mantle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,14 @@ Master list of UniV3 forks:
 
 ---
 
+## [Unreleased]
+
+### Breaking changes
+
+### Non-breaking changes
+
+* Add Dodo V2 on Mantle
+
 ## 2024-09-09
 
 ### Breaking changes


### PR DESCRIPTION
When attempting to add DodoV2 as a liquidity source on Mantle, I started getting `ActionInvalid` errors. After some investigation, it seems we just don't support dispatching DodoV2 calls on Mantle.

This PR adds support for selling to DodoV2 on Mantle. Feel free to close if this doesn't make sense, or let me know what I can change here to add support properly. I have not tested it.

IIUC, we are not adding integration tests for every single chain/action pair, but if we want to test this specific change, I'm happy to do so if you give me some pointers (I guess it would look very similar to the DodoV2 integration test).