### PR TITLE
[dependabot] enable slack alerts every hour

### DIFF
--- a/.github/workflows/dependabot-slack-alerts.yml
+++ b/.github/workflows/dependabot-slack-alerts.yml
@@ -5,9 +5,8 @@ permissions:
   security-events: read
 
 on:
-  # TODO: enable hourly run once tested
-  #schedule:
-  #  - cron: '0 * * * *'
+  schedule:
+    - cron: '0 * * * *'
   workflow_dispatch:
 jobs:
   notify-vulnerabilites:


### PR DESCRIPTION
Enables slack alerts every hour, all current alerts should be fixed before merging

@0xProject/platform-engineering 