### PR TITLE
Fix foundry up installation suggested command 

### DIFF
--- a/sh/common.sh
+++ b/sh/common.sh
@@ -11,7 +11,7 @@ forge_version="${forge_version:13:7}"
 declare -r forge_version
 if [[ $forge_version != '59f354c' ]] ; then
     echo 'Wrong foundry version installed -- '"$forge_version" >&2
-    echo 'Run `foundryup -v nightly-59f354c179f4e7f6d7292acb3d068815c79286d1`' >&2
+    echo 'Run `foundryup -i nightly-59f354c179f4e7f6d7292acb3d068815c79286d1`' >&2
     exit 1
 fi
 


### PR DESCRIPTION
Update the error comment to install the right version of Foundry for deployment. It currently uses `-v` but it should be `-i` as showed below
<img width="519" alt="image" src="https://github.com/user-attachments/assets/e3eec933-e943-430d-a0a4-3781f37631f3" />
