### PR TITLE
fix: UniswapV2 restore FMP [SLV-1702]

### DIFF
--- a/src/core/UniswapV2.sol
+++ b/src/core/UniswapV2.sol
@@ -136,6 +136,9 @@ abstract contract UniswapV2 is SettlerAbstract {
             // perform swap at the pool sending bought tokens to the recipient
             if iszero(call(gas(), pool, 0, swapCalldata, 0xa4, 0, 0)) { bubbleRevert(ptr) }
 
+            // restore FMP
+            mstore(0x40, ptr)
+
             // revert with the return data from the most recent call
             function bubbleRevert(p) {
                 returndatacopy(p, 0, returndatasize())


### PR DESCRIPTION
[Reports](https://0xproject.slack.com/archives/C06AR65AQDN/p1759779964542249) of Reth crashing due to OOM. On Geth this appears to be protected an a `EvmError: MemoryOOG` revert instead.

Clobbering `0x40` without a restore seems to be the culprit.

```
    │   │   │   ├─ [2504] UniswapV2Pair::getReserves() [staticcall]
    │   │   │   │   └─ ← [Return] 61435883960845707417266860 [6.143e25], 13367856774488742437 [1.336e19]
    │   │   │   ├─ [90708] UniswapV2Pair::swap(52651013787451206646206 [5.265e22], 0, 0xD24763A50d49075748739Bd541433F57Bb9A8285, 0x)
    │   │   │   │   ├─ [66216] DISCO::transfer(0xD24763A50d49075748739Bd541433F57Bb9A8285, 52651013787451206646206 [5.265e22])
    │   │   │   │   │   ├─ emit Transfer(from: UniswapV2Pair: [0x807Ac92BC2F76876c2b20AD862D67A58727dC73c], to: 0xD24763A50d49075748739Bd541433F57Bb9A8285, value: 52651013787451206646206 [5.265e22])
    │   │   │   │   │   └─ ← [Return] true
    │   │   │   │   ├─ [551] DISCO::balanceOf(UniswapV2Pair: [0x807Ac92BC2F76876c2b20AD862D67A58727dC73c]) [staticcall]
    │   │   │   │   │   └─ ← [Return] 61383232947058256210620654 [6.138e25]
    │   │   │   │   ├─ [534] WETH9::balanceOf(UniswapV2Pair: [0x807Ac92BC2F76876c2b20AD862D67A58727dC73c]) [staticcall]
    │   │   │   │   │   └─ ← [Return] 13379357456753664838 [1.337e19]
    │   │   │   │   ├─ emit Sync(reserve0: 61383232947058256210620654 [6.138e25], reserve1: 13379357456753664838 [1.337e19])
    │   │   │   │   ├─ emit Swap(sender: MainnetSettler: [0x207e1074858A7e78f17002075739eD2745dbaEce], amount0In: 0, amount1In: 11500682264922401 [1.15e16], amount0Out: 52651013787451206646206 [5.265e22], amount1Out: 0, to: 0xD24763A50d49075748739Bd541433F57Bb9A8285)
    │   │   │   │   └─ ← [Stop]
    │   │   │   └─ ← [MemoryOOG] EvmError: MemoryOOG
    │   │   └─ ← [Revert] EvmError: Revert
```

https://gist.github.com/dekz/fb5329cab57c1eb3073a80de014340f9

After these changes have been applied

```
    │   │   │   ├─ [2504] UniswapV2Pair::getReserves() [staticcall]
    │   │   │   │   └─ ← [Return] 61435883960845707417266860 [6.143e25], 13367856774488742437 [1.336e19]
    │   │   │   ├─ [90708] UniswapV2Pair::swap(52651013787451206646206 [5.265e22], 0, 0xD24763A50d49075748739Bd541433F57Bb9A8285, 0x)
    │   │   │   │   ├─ [66216] DISCO::transfer(0xD24763A50d49075748739Bd541433F57Bb9A8285, 52651013787451206646206 [5.265e22])
    │   │   │   │   │   ├─ emit Transfer(from: UniswapV2Pair: [0x807Ac92BC2F76876c2b20AD862D67A58727dC73c], to: 0xD24763A50d49075748739Bd541433F57Bb9A8285, value: 52651013787451206646206 [5.265e22])
    │   │   │   │   │   └─ ← [Return] true
    │   │   │   │   ├─ [551] DISCO::balanceOf(UniswapV2Pair: [0x807Ac92BC2F76876c2b20AD862D67A58727dC73c]) [staticcall]
    │   │   │   │   │   └─ ← [Return] 61383232947058256210620654 [6.138e25]
    │   │   │   │   ├─ [534] WETH9::balanceOf(UniswapV2Pair: [0x807Ac92BC2F76876c2b20AD862D67A58727dC73c]) [staticcall]
    │   │   │   │   │   └─ ← [Return] 13379357456753664838 [1.337e19]
    │   │   │   │   ├─ emit Sync(reserve0: 61383232947058256210620654 [6.138e25], reserve1: 13379357456753664838 [1.337e19])
    │   │   │   │   ├─ emit Swap(sender: MainnetSettler: [0x207e1074858A7e78f17002075739eD2745dbaEce], amount0In: 0, amount1In: 11500682264922401 [1.15e16], amount0Out: 52651013787451206646206 [5.265e22], amount1Out: 0, to: 0xD24763A50d49075748739Bd541433F57Bb9A8285)
    │   │   │   │   └─ ← [Stop]
    │   │   │   ├─ [381] UniswapV2Pair::token0() [staticcall]
    │   │   │   │   └─ ← [Return] DISCO: [0x787B197F793F7D04366536F6a7a56a799868A64b]
    │   │   │   └─ ← [Revert] custom error 0x97a6f3b9: 000000000000000000000000787b197f793f7d04366536f6a7a56a799868a64b000000000000000000000000000000000000000000000b5171a366d5380f847c000000000000000000000000000000000000000000000b263798e2a90753b9be
    │   │   └─ ← [Revert] custom error 0x97a6f3b9: 000000000000000000000000787b197f793f7d04366536f6a7a56a799868a64b000000000000000000000000000000000000000000000b5171a366d5380f847c000000000000000000000000000000000000000000000b263798e2a90753b9be
```
    
```
    cast cdd 'TooMuchSlippage(address,uint256,uint256)' 0x97a6f3b9000000000000000000000000787b197f793f7d04366536f6a7a56a799868a64b000000000000000000000000000000000000000000000b5171a366d5380f847c000000000000000000000000000000000000000000000b263798e2a90753b9be
0x787B197F793F7D04366536F6a7a56a799868A64b
53448406083150015333500 [5.344e22]
52651013787451206646206 [5.265e22]
```
 