### PR TITLE
chore: upload dao deployed safe addresses

### DIFF
--- a/chain_config.json
+++ b/chain_config.json
@@ -592,7 +592,7 @@
       "upgradeSafe": "0xC6eE74143546ab222bFB6FDDB5726D0502B39184",
       "deploymentSafe": "0x059bD6D6DDE3769A7467fE21cC5a2C4c30D3dbfb",
       "pause": "0x1CeC01DC0fFEE5eB5aF47DbEc1809F2A7c601C30",
-      "daoSafe": "null"
+      "daoSafe": null
     },
     "deployment": {
       "deployer": "0x00000000000004533Fe15556B1E086BB1A72cEae",


### PR DESCRIPTION
- upload dao safe addresses
- deployer is factory 0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67
- singleton v1.4.1 0x41675C099F32341bf84BFc5382aF534df5C7461a
- monad-testnet market "NaN" as singleton v1.4.1 has not been deployed there (dao will maintain same safe address across chains)