### PR TITLE
Remove SolidlyV3 UniV3 fork from Mainnet and Sonic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Breaking changes
 
+* SolidlyV3 UniV3 fork removed from Mainnet and Sonic
+
 ### Non-breaking changes
 
 ## 2026-04-10

--- a/src/chains/Mainnet/Common.sol
+++ b/src/chains/Mainnet/Common.sol
@@ -40,12 +40,6 @@ import {
     IPancakeSwapV3Callback
 } from "../../core/univ3forks/PancakeSwapV3.sol";
 import {sushiswapV3MainnetFactory, sushiswapV3ForkId} from "../../core/univ3forks/SushiswapV3.sol";
-import {
-    solidlyV3Factory,
-    solidlyV3InitHash,
-    solidlyV3ForkId,
-    ISolidlyV3Callback
-} from "../../core/univ3forks/SolidlyV3.sol";
 
 import {MAINNET_POOL_MANAGER} from "../../core/UniswapV4Addresses.sol";
 
@@ -224,10 +218,6 @@ abstract contract MainnetMixin is
             factory = sushiswapV3MainnetFactory;
             initHash = uniswapV3InitHash;
             callbackSelector = uint32(IUniswapV3Callback.uniswapV3SwapCallback.selector);
-        } else if (forkId == solidlyV3ForkId) {
-            factory = solidlyV3Factory;
-            initHash = solidlyV3InitHash;
-            callbackSelector = uint32(ISolidlyV3Callback.solidlyV3SwapCallback.selector);
         } else {
             revertUnknownForkId(forkId);
         }

--- a/src/chains/Sonic/Common.sol
+++ b/src/chains/Sonic/Common.sol
@@ -17,12 +17,6 @@ import {
     uniswapV3ForkId,
     IUniswapV3Callback
 } from "../../core/univ3forks/UniswapV3.sol";
-import {
-    solidlyV3SonicFactory,
-    solidlyV3InitHash,
-    solidlyV3ForkId,
-    ISolidlyV3Callback
-} from "../../core/univ3forks/SolidlyV3.sol";
 import {spookySwapFactory, spookySwapForkId} from "../../core/univ3forks/SpookySwap.sol";
 import {wagmiFactory, wagmiInitHash, wagmiForkId} from "../../core/univ3forks/Wagmi.sol";
 import {swapXFactory, swapXForkId} from "../../core/univ3forks/SwapX.sol";
@@ -80,10 +74,6 @@ abstract contract SonicMixin is FreeMemory, SettlerBase, EulerSwap, BalancerV3 {
             factory = uniswapV3SonicFactory;
             initHash = uniswapV3InitHash;
             callbackSelector = uint32(IUniswapV3Callback.uniswapV3SwapCallback.selector);
-        } else if (forkId == solidlyV3ForkId) {
-            factory = solidlyV3SonicFactory;
-            initHash = solidlyV3InitHash;
-            callbackSelector = uint32(ISolidlyV3Callback.solidlyV3SwapCallback.selector);
         } else if (forkId == spookySwapForkId) {
             factory = spookySwapFactory;
             initHash = uniswapV3InitHash;


### PR DESCRIPTION
Remove Solidly v3 UniV3 fork from Mainnet and Sonic

Reasoning:
- Solidly v3 on Mainnet and Sonic sees no 0x API volume. All of its activity is on Op, Base, and Arb
- Saves ~200B on MainnetSettler (margin: 636B → 836B), ~200B on SonicSettler
- Similar to previous work https://github.com/0xProject/0x-settler/pull/493/changes

[Metabase query showing Solidly v3 vol](https://metabase-clean.spaceship.0x.org/question/2649-solidlyv3-volume-by-chain-90d)

<img width="761" height="380" alt="Screenshot 2026-04-13 at 2 35 06 PM" src="https://github.com/user-attachments/assets/c42a84ce-20a2-4b2e-994d-fd5bec29c775" />


