### PR TITLE
Add Nucleus Teller bridge support for WPAXG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,11 @@
 
 ### Non-breaking changes
 
-## 2026-04-10
+* Add `BRIDGE_TO_NUCLEUS_TELLER` and `DEPOSIT_AND_BRIDGE_TO_NUCLEUS_TELLER`
+  actions for bridging through the Paxos Nucleus WPAXG `CrossChainTellerBase`
+  (LayerZero under the hood). Available on Mainnet (both actions) and
+  Optimism (`BRIDGE_TO_NUCLEUS_TELLER` only; PAXG is Ethereum-only).
+  Teller and BoringVault addresses are hardcoded.
 
 ### Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
   Optimism (`BRIDGE_TO_NUCLEUS_TELLER` only; PAXG is Ethereum-only).
   Teller and BoringVault addresses are hardcoded.
 
+## 2026-04-10
+
 ### Breaking changes
 
 * Abandon Mode chain

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,9 @@
 
 ### Non-breaking changes
 
-* Add `BRIDGE_TO_NUCLEUS_TELLER` and `DEPOSIT_AND_BRIDGE_TO_NUCLEUS_TELLER`
-  actions for bridging through the Paxos Nucleus WPAXG `CrossChainTellerBase`
-  (LayerZero under the hood). Available on Mainnet (both actions) and
-  Optimism (`BRIDGE_TO_NUCLEUS_TELLER` only; PAXG is Ethereum-only).
-  Teller and BoringVault addresses are hardcoded.
+* Add `BRIDGE_TO_NUCLEUS_TELLER` (Mainnet and Optimism) and
+  `DEPOSIT_AND_BRIDGE_TO_NUCLEUS_TELLER` (Mainnet) actions for bridging WPAXG
+  through Nucleus Teller
 
 ## 2026-04-10
 

--- a/src/bridge/IBridgeSettlerActions.sol
+++ b/src/bridge/IBridgeSettlerActions.sol
@@ -47,4 +47,13 @@ interface IBridgeSettlerActions {
 
     /// @dev Bridge ERC20 through Chainlink CCIP, paying fees in native token
     function BRIDGE_TO_CCIP(address router, bytes calldata ccipSendData) external;
+
+    /// @dev Bridge BoringVault shares through a Paxos Nucleus `CrossChainTellerBase`, paying fees in native token.
+    /// Pre-req: BridgeSettler holds shares of the BoringVault associated with `teller`.
+    function BRIDGE_TO_NUCLEUS_TELLER(address teller, bytes calldata bridgeCallData) external;
+
+    /// @dev Deposit an ERC20 into a Paxos Nucleus BoringVault and bridge the resulting shares
+    /// through its `CrossChainTellerBase` in one call, paying fees in native token.
+    /// Pre-req: BridgeSettler holds the deposit asset encoded in `depositAndBridgeCallData`.
+    function DEPOSIT_AND_BRIDGE_TO_NUCLEUS_TELLER(address teller, bytes calldata depositAndBridgeCallData) external;
 }

--- a/src/bridge/IBridgeSettlerActions.sol
+++ b/src/bridge/IBridgeSettlerActions.sol
@@ -49,11 +49,9 @@ interface IBridgeSettlerActions {
     function BRIDGE_TO_CCIP(address router, bytes calldata ccipSendData) external;
 
     /// @dev Bridge BoringVault shares through the Paxos Nucleus WPAXG `CrossChainTellerBase`, paying fees in native token.
-    /// Pre-req: BridgeSettler holds WPAXG shares.
     function BRIDGE_TO_NUCLEUS_TELLER(bytes calldata bridgeCallData) external;
 
     /// @dev Deposit PAXG into the Paxos Nucleus WPAXG BoringVault and bridge the resulting shares
     /// through its `CrossChainTellerBase` in one call, paying fees in native token.
-    /// Pre-req: BridgeSettler holds the deposit asset encoded in `depositAndBridgeCallData`.
     function DEPOSIT_AND_BRIDGE_TO_NUCLEUS_TELLER(bytes calldata depositAndBridgeCallData) external;
 }

--- a/src/bridge/IBridgeSettlerActions.sol
+++ b/src/bridge/IBridgeSettlerActions.sol
@@ -48,12 +48,12 @@ interface IBridgeSettlerActions {
     /// @dev Bridge ERC20 through Chainlink CCIP, paying fees in native token
     function BRIDGE_TO_CCIP(address router, bytes calldata ccipSendData) external;
 
-    /// @dev Bridge BoringVault shares through a Paxos Nucleus `CrossChainTellerBase`, paying fees in native token.
-    /// Pre-req: BridgeSettler holds shares of the BoringVault associated with `teller`.
-    function BRIDGE_TO_NUCLEUS_TELLER(address teller, bytes calldata bridgeCallData) external;
+    /// @dev Bridge BoringVault shares through the Paxos Nucleus WPAXG `CrossChainTellerBase`, paying fees in native token.
+    /// Pre-req: BridgeSettler holds WPAXG shares.
+    function BRIDGE_TO_NUCLEUS_TELLER(bytes calldata bridgeCallData) external;
 
-    /// @dev Deposit an ERC20 into a Paxos Nucleus BoringVault and bridge the resulting shares
+    /// @dev Deposit PAXG into the Paxos Nucleus WPAXG BoringVault and bridge the resulting shares
     /// through its `CrossChainTellerBase` in one call, paying fees in native token.
     /// Pre-req: BridgeSettler holds the deposit asset encoded in `depositAndBridgeCallData`.
-    function DEPOSIT_AND_BRIDGE_TO_NUCLEUS_TELLER(address teller, bytes calldata depositAndBridgeCallData) external;
+    function DEPOSIT_AND_BRIDGE_TO_NUCLEUS_TELLER(bytes calldata depositAndBridgeCallData) external;
 }

--- a/src/bridge/IBridgeSettlerActions.sol
+++ b/src/bridge/IBridgeSettlerActions.sol
@@ -48,10 +48,10 @@ interface IBridgeSettlerActions {
     /// @dev Bridge ERC20 through Chainlink CCIP, paying fees in native token
     function BRIDGE_TO_CCIP(address router, bytes calldata ccipSendData) external;
 
-    /// @dev Bridge BoringVault shares through the Paxos Nucleus WPAXG `CrossChainTellerBase`, paying fees in native token.
+    /// @dev Bridge WPAXG through Nucleus Teller, paying fees in native token.
     function BRIDGE_TO_NUCLEUS_TELLER(bytes calldata bridgeCallData) external;
 
-    /// @dev Deposit PAXG into the Paxos Nucleus WPAXG BoringVault and bridge the resulting shares
-    /// through its `CrossChainTellerBase` in one call, paying fees in native token.
+    /// @dev Wraps PAXG into WPAXG and bridges the resulting shares through Nucleus Teller,
+    /// paying fees in native token.
     function DEPOSIT_AND_BRIDGE_TO_NUCLEUS_TELLER(bytes calldata depositAndBridgeCallData) external;
 }

--- a/src/chains/Mainnet/BridgeSettler.sol
+++ b/src/chains/Mainnet/BridgeSettler.sol
@@ -38,11 +38,11 @@ contract MainnetBridgeSettler is BridgeSettler, Across, Mayan, StargateV2, DeBri
             (uint256 globalFee, bytes memory createOrderData) = abi.decode(data, (uint256, bytes));
             bridgeToDeBridge(globalFee, createOrderData);
         } else if (action == uint32(IBridgeSettlerActions.BRIDGE_TO_NUCLEUS_TELLER.selector)) {
-            (address teller, bytes memory bridgeCallData) = abi.decode(data, (address, bytes));
-            bridgeToNucleusTeller(teller, bridgeCallData);
+            bytes memory bridgeCallData = abi.decode(data, (bytes));
+            bridgeToNucleusTeller(bridgeCallData);
         } else if (action == uint32(IBridgeSettlerActions.DEPOSIT_AND_BRIDGE_TO_NUCLEUS_TELLER.selector)) {
-            (address teller, bytes memory depositAndBridgeCallData) = abi.decode(data, (address, bytes));
-            depositAndBridgeToNucleusTeller(teller, depositAndBridgeCallData);
+            bytes memory depositAndBridgeCallData = abi.decode(data, (bytes));
+            depositAndBridgeToNucleusTeller(depositAndBridgeCallData);
         } else {
             return false;
         }

--- a/src/chains/Mainnet/BridgeSettler.sol
+++ b/src/chains/Mainnet/BridgeSettler.sol
@@ -9,8 +9,9 @@ import {Across} from "../../core/Across.sol";
 import {Mayan} from "../../core/Mayan.sol";
 import {StargateV2} from "../../core/StargateV2.sol";
 import {DeBridge} from "../../core/DeBridge.sol";
+import {NucleusTeller} from "../../core/NucleusTeller.sol";
 
-contract MainnetBridgeSettler is BridgeSettler, Across, Mayan, StargateV2, DeBridge {
+contract MainnetBridgeSettler is BridgeSettler, Across, Mayan, StargateV2, DeBridge, NucleusTeller {
     constructor(bytes20 gitCommit) BridgeSettlerBase(gitCommit) {
         assert(block.chainid == 1 || block.chainid == 31337);
     }
@@ -36,6 +37,12 @@ contract MainnetBridgeSettler is BridgeSettler, Across, Mayan, StargateV2, DeBri
         } else if (action == uint32(IBridgeSettlerActions.BRIDGE_TO_DEBRIDGE.selector)) {
             (uint256 globalFee, bytes memory createOrderData) = abi.decode(data, (uint256, bytes));
             bridgeToDeBridge(globalFee, createOrderData);
+        } else if (action == uint32(IBridgeSettlerActions.BRIDGE_TO_NUCLEUS_TELLER.selector)) {
+            (address teller, bytes memory bridgeCallData) = abi.decode(data, (address, bytes));
+            bridgeToNucleusTeller(teller, bridgeCallData);
+        } else if (action == uint32(IBridgeSettlerActions.DEPOSIT_AND_BRIDGE_TO_NUCLEUS_TELLER.selector)) {
+            (address teller, bytes memory depositAndBridgeCallData) = abi.decode(data, (address, bytes));
+            depositAndBridgeToNucleusTeller(teller, depositAndBridgeCallData);
         } else {
             return false;
         }

--- a/src/chains/Optimism/BridgeSettler.sol
+++ b/src/chains/Optimism/BridgeSettler.sol
@@ -41,8 +41,8 @@ contract OptimismBridgeSettler is BridgeSettler, Across, Mayan, StargateV2, DeBr
             (uint256 globalFee, bytes memory createOrderData) = abi.decode(data, (uint256, bytes));
             bridgeToDeBridge(globalFee, createOrderData);
         } else if (action == uint32(IBridgeSettlerActions.BRIDGE_TO_NUCLEUS_TELLER.selector)) {
-            (address teller, bytes memory bridgeCallData) = abi.decode(data, (address, bytes));
-            bridgeToNucleusTeller(teller, bridgeCallData);
+            bytes memory bridgeCallData = abi.decode(data, (bytes));
+            bridgeToNucleusTeller(bridgeCallData);
         } else {
             return false;
         }

--- a/src/chains/Optimism/BridgeSettler.sol
+++ b/src/chains/Optimism/BridgeSettler.sol
@@ -8,8 +8,9 @@ import {Across} from "../../core/Across.sol";
 import {Mayan} from "../../core/Mayan.sol";
 import {StargateV2} from "../../core/StargateV2.sol";
 import {DeBridge} from "../../core/DeBridge.sol";
+import {NucleusTeller} from "../../core/NucleusTeller.sol";
 
-contract OptimismBridgeSettler is BridgeSettler, Across, Mayan, StargateV2, DeBridge {
+contract OptimismBridgeSettler is BridgeSettler, Across, Mayan, StargateV2, DeBridge, NucleusTeller {
     constructor(bytes20 gitCommit) BridgeSettlerBase(gitCommit) {
         assert(block.chainid == 10 || block.chainid == 31337);
     }
@@ -39,6 +40,9 @@ contract OptimismBridgeSettler is BridgeSettler, Across, Mayan, StargateV2, DeBr
         } else if (action == uint32(IBridgeSettlerActions.BRIDGE_TO_DEBRIDGE.selector)) {
             (uint256 globalFee, bytes memory createOrderData) = abi.decode(data, (uint256, bytes));
             bridgeToDeBridge(globalFee, createOrderData);
+        } else if (action == uint32(IBridgeSettlerActions.BRIDGE_TO_NUCLEUS_TELLER.selector)) {
+            (address teller, bytes memory bridgeCallData) = abi.decode(data, (address, bytes));
+            bridgeToNucleusTeller(teller, bridgeCallData);
         } else {
             return false;
         }

--- a/src/core/NucleusTeller.sol
+++ b/src/core/NucleusTeller.sol
@@ -4,6 +4,11 @@ pragma solidity ^0.8.25;
 import {IERC20} from "@forge-std/interfaces/IERC20.sol";
 import {SafeTransferLib} from "../vendor/SafeTransferLib.sol";
 
+/// @dev Mirrors the relevant subset of paxoslabs/nucleus-boring-vault `AccountantWithRateProviders`.
+interface INucleusAccountant {
+    function getRateInQuoteSafe(IERC20 quote) external view returns (uint256);
+}
+
 /// @dev Mirrors the relevant subset of paxoslabs/nucleus-boring-vault `CrossChainTellerBase`.
 /// `BridgeData` follows `src/interfaces/ICrossChainTypes.sol` from that repo.
 interface INucleusTeller {
@@ -22,6 +27,10 @@ interface INucleusTeller {
         payable;
 
     function previewFee(uint256 shareAmount, BridgeData calldata data) external view returns (uint256);
+
+    function accountant() external view returns (INucleusAccountant);
+
+    function vault() external view returns (IERC20);
 }
 
 /// @title NucleusTeller

--- a/src/core/NucleusTeller.sol
+++ b/src/core/NucleusTeller.sol
@@ -4,13 +4,9 @@ pragma solidity ^0.8.25;
 import {IERC20} from "@forge-std/interfaces/IERC20.sol";
 import {SafeTransferLib} from "../vendor/SafeTransferLib.sol";
 
-/// @dev Mirrors the relevant subset of paxoslabs/nucleus-boring-vault `AccountantWithRateProviders`.
-interface INucleusAccountant {
-    function getRateInQuoteSafe(IERC20 quote) external view returns (uint256);
-}
-
-/// @dev Mirrors the relevant subset of paxoslabs/nucleus-boring-vault `CrossChainTellerBase`.
-/// `BridgeData` follows `src/interfaces/ICrossChainTypes.sol` from that repo.
+/// @dev Mirrors the relevant subset of paxoslabs/nucleus-boring-vault
+/// `MultiChainLayerZeroTellerWithMultiAssetSupport`. `BridgeData` follows
+/// `src/interfaces/ICrossChainTypes.sol` from that repo.
 interface INucleusTeller {
     struct BridgeData {
         uint32 chainSelector;
@@ -27,20 +23,16 @@ interface INucleusTeller {
         payable;
 
     function previewFee(uint256 shareAmount, BridgeData calldata data) external view returns (uint256);
-
-    function accountant() external view returns (INucleusAccountant);
-
-    function vault() external view returns (IERC20);
 }
 
 /// @title NucleusTeller
-/// @notice BridgeSettler integration for the Paxos Nucleus WPAXG `CrossChainTellerBase`.
+/// @notice BridgeSettler integration for the Paxos Nucleus WPAXG Teller.
 /// @dev The Teller and WPAXG share token addresses are identical on every chain the deployment
 /// supports (Ethereum and Optimism), so they are hardcoded.
 contract NucleusTeller {
     using SafeTransferLib for IERC20;
 
-    /// @notice Paxos Nucleus WPAXG `CrossChainTellerBase` (same address on Ethereum and Optimism)
+    /// @notice Paxos Nucleus WPAXG Teller (same address on Ethereum and Optimism)
     address internal constant NUCLEUS_TELLER = 0xeE98730AAAdA5e6e092cA69F1AC1B9B554c059dF;
 
     /// @notice WPAXG share token / Nucleus `BoringVault` (same address on Ethereum and Optimism)

--- a/src/core/NucleusTeller.sol
+++ b/src/core/NucleusTeller.sol
@@ -26,9 +26,7 @@ interface INucleusTeller {
 }
 
 /// @title NucleusTeller
-/// @notice BridgeSettler integration for the Paxos Nucleus WPAXG Teller.
-/// @dev The Teller and WPAXG share token addresses are identical on every chain the deployment
-/// supports (Ethereum and Optimism), so they are hardcoded.
+/// @notice BridgeSettler integration for Nucleus Teller WPAXG.
 contract NucleusTeller {
     using SafeTransferLib for IERC20;
 

--- a/src/core/NucleusTeller.sol
+++ b/src/core/NucleusTeller.sol
@@ -26,8 +26,9 @@ interface INucleusTeller {
 
 /// @title NucleusTeller
 /// @notice BridgeSettler integration for the Paxos Nucleus WPAXG `CrossChainTellerBase`.
-/// @dev Native bridge fees are paid from the contract's full ETH balance. Per Paxos Nucleus, any
-/// excess is consumed by the underlying messaging protocol (LayerZero) and is not refunded.
+/// @dev Native bridge fees are paid from the contract's full ETH balance. The underlying
+/// LayerZero endpoint refunds any excess back to this contract via the Teller's
+/// `payable(msg.sender)` refund address.
 /// The Teller and WPAXG share token addresses are identical on every chain the deployment
 /// supports (Ethereum and Optimism), so they are hardcoded.
 contract NucleusTeller {
@@ -40,8 +41,6 @@ contract NucleusTeller {
     IERC20 internal constant WPAXG = IERC20(0x5cB5C4d5e8B184A364534bc688DA0553Ccf8F484);
 
     /// @notice Bridge WPAXG shares held by this contract via the Nucleus Teller.
-    /// @dev `bridge` burns shares from `msg.sender` (this contract) via `vault.exit(...)`, so the
-    /// shares must already be sitting here. No approval is required.
     /// @param bridgeCallData Encoded args (no selector) to `INucleusTeller.bridge`:
     ///        `(shareAmount, BridgeData)`. `shareAmount` is overridden with this contract's
     ///        WPAXG balance.
@@ -59,9 +58,6 @@ contract NucleusTeller {
     }
 
     /// @notice Deposit `depositAsset` into the WPAXG BoringVault and bridge the resulting shares.
-    /// @dev `depositAndBridge` pulls `depositAsset` from `msg.sender` (this contract) into the
-    /// BoringVault, mints shares to `msg.sender`, then immediately burns and bridges them. WPAXG
-    /// — the BoringVault, not the Teller — needs the ERC20 approval.
     /// @param depositAndBridgeCallData Encoded args (no selector) to `INucleusTeller.depositAndBridge`:
     ///        `(depositAsset, depositAmount, minimumMint, BridgeData)`. `depositAmount` is
     ///        overridden with this contract's balance of `depositAsset`.
@@ -87,16 +83,16 @@ contract NucleusTeller {
         _callTeller(0xbfe1a0f2, depositAndBridgeCallData);
     }
 
-    /// @dev Calls `NUCLEUS_TELLER` with `selector` prepended to `data`, forwarding the full ETH
-    /// balance as msg.value. Temporarily clobbers and restores the `data` length slot to avoid
-    /// allocating a new memory buffer. Bubbles up any revert data.
+    /// @dev Calls `NUCLEUS_TELLER` with `selector` prepended to `data`, forwarding the full ETH balance.
     function _callTeller(uint256 selector, bytes memory data) private {
         assembly ("memory-safe") {
             let len := mload(data)
             // Temporarily clobber the bytes length slot with the function selector
             mstore(data, selector)
 
-            // The hardcoded `NUCLEUS_TELLER` cannot clash with restricted targets (AllowanceHolder & Permit2)
+            // `NUCLEUS_TELLER` is hardcoded and doesn't clash with restricted targets (AllowanceHolder & Permit2).
+            // `selfbalance()` is safe: the underlying LayerZero endpoint refunds any excess to this
+            // contract via the Teller's `payable(msg.sender)` refund address.
             if iszero(call(gas(), NUCLEUS_TELLER, selfbalance(), add(0x1c, data), add(0x04, len), 0x00, 0x00)) {
                 let ptr := mload(0x40)
                 returndatacopy(ptr, 0x00, returndatasize())

--- a/src/core/NucleusTeller.sol
+++ b/src/core/NucleusTeller.sol
@@ -53,9 +53,6 @@ contract NucleusTeller {
     }
 
     /// @notice Deposit `depositAsset` into the WPAXG BoringVault and bridge the resulting shares.
-    /// @dev `depositAmount` is overridden with this contract's runtime balance of `depositAsset`;
-    /// `minimumMint` is passed through as a strict slippage check. Dirty upper bits in the encoded
-    /// `depositAsset` aren't masked here; the Teller's ABI decoder will reject them down the line.
     /// @param depositAndBridgeCallData Encoded args (no selector) to `INucleusTeller.depositAndBridge`.
     function depositAndBridgeToNucleusTeller(bytes memory depositAndBridgeCallData) internal {
         IERC20 depositAsset;
@@ -66,6 +63,8 @@ contract NucleusTeller {
             // +0x40: depositAmount             <- override
             // +0x60: minimumMint
             // +0x80: offset to BridgeData tuple
+            // Dirty upper bits in `depositAsset` aren't masked; the Teller's ABI decoder will
+            // reject them down the line.
             depositAsset := mload(add(0x20, depositAndBridgeCallData))
         }
 

--- a/src/core/NucleusTeller.sol
+++ b/src/core/NucleusTeller.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.25;
 
 import {IERC20} from "@forge-std/interfaces/IERC20.sol";
 import {SafeTransferLib} from "../vendor/SafeTransferLib.sol";
-import {tmp} from "../utils/512Math.sol";
 
 /// @dev Mirrors the relevant subset of the deployed Nucleus WPAXG Teller
 /// (0xeE98730AAAdA5e6e092cA69F1AC1B9B554c059dF), sourced from paxoslabs/nucleus-boring-vault at
@@ -54,36 +53,27 @@ contract NucleusTeller {
     }
 
     /// @notice Deposit `depositAsset` into the WPAXG BoringVault and bridge the resulting shares.
-    /// @dev `depositAmount` is overridden with this contract's runtime balance of `depositAsset`,
-    /// and `minimumMint` is scaled by the same ratio so the caller's slippage tolerance is
-    /// preserved. Dirty upper bits in the encoded `depositAsset` aren't masked here; the Teller's
-    /// ABI decoder will reject them down the line.
+    /// @dev `depositAmount` is overridden with this contract's runtime balance of `depositAsset`;
+    /// `minimumMint` is passed through as a strict slippage check. Dirty upper bits in the encoded
+    /// `depositAsset` aren't masked here; the Teller's ABI decoder will reject them down the line.
     /// @param depositAndBridgeCallData Encoded args (no selector) to `INucleusTeller.depositAndBridge`.
     function depositAndBridgeToNucleusTeller(bytes memory depositAndBridgeCallData) internal {
         IERC20 depositAsset;
-        uint256 encodedDepositAmount;
-        uint256 encodedMinimumMint;
         assembly ("memory-safe") {
             // depositAndBridgeCallData layout in memory:
             // +0x00: bytes length
             // +0x20: depositAsset              <- read
             // +0x40: depositAmount             <- override
-            // +0x60: minimumMint               <- override
+            // +0x60: minimumMint
             // +0x80: offset to BridgeData tuple
             depositAsset := mload(add(0x20, depositAndBridgeCallData))
-            encodedDepositAmount := mload(add(0x40, depositAndBridgeCallData))
-            encodedMinimumMint := mload(add(0x60, depositAndBridgeCallData))
         }
 
         uint256 depositAmount = depositAsset.fastBalanceOf(address(this));
         depositAsset.safeApproveIfBelow(address(WPAXG), depositAmount);
 
-        // Scale `minimumMint` proportionally to the actual deposit amount.
-        uint256 minimumMint = tmp().omul(encodedMinimumMint, depositAmount).div(encodedDepositAmount);
-
         assembly ("memory-safe") {
             mstore(add(0x40, depositAndBridgeCallData), depositAmount)
-            mstore(add(0x60, depositAndBridgeCallData), minimumMint)
         }
         // selector for `depositAndBridge(address,uint256,uint256,(uint32,address,address,uint64,bytes))`
         _callTeller(0xbfe1a0f2, depositAndBridgeCallData);

--- a/src/core/NucleusTeller.sol
+++ b/src/core/NucleusTeller.sol
@@ -4,8 +4,9 @@ pragma solidity ^0.8.25;
 import {IERC20} from "@forge-std/interfaces/IERC20.sol";
 import {SafeTransferLib} from "../vendor/SafeTransferLib.sol";
 
-/// @dev Mirrors the relevant subset of paxoslabs/nucleus-boring-vault
-/// `MultiChainLayerZeroTellerWithMultiAssetSupport`. `BridgeData` follows
+/// @dev Mirrors the relevant subset of the deployed Nucleus WPAXG Teller
+/// (0xeE98730AAAdA5e6e092cA69F1AC1B9B554c059dF), sourced from paxoslabs/nucleus-boring-vault at
+/// commit d9a1dff0098b4f0cc81e264f2dbe0d244e065b81. `BridgeData` follows
 /// `src/interfaces/ICrossChainTypes.sol` from that repo.
 interface INucleusTeller {
     struct BridgeData {
@@ -52,24 +53,37 @@ contract NucleusTeller {
     }
 
     /// @notice Deposit `depositAsset` into the WPAXG BoringVault and bridge the resulting shares.
+    /// @dev `depositAmount` is overridden with this contract's runtime balance of `depositAsset`,
+    /// and `minimumMint` is scaled by the same ratio so the caller's slippage tolerance is
+    /// preserved. Dirty upper bits in the encoded `depositAsset` aren't masked here; the Teller's
+    /// ABI decoder will reject them down the line.
     /// @param depositAndBridgeCallData Encoded args (no selector) to `INucleusTeller.depositAndBridge`.
     function depositAndBridgeToNucleusTeller(bytes memory depositAndBridgeCallData) internal {
         IERC20 depositAsset;
+        uint256 encodedDepositAmount;
+        uint256 encodedMinimumMint;
         assembly ("memory-safe") {
             // depositAndBridgeCallData layout in memory:
             // +0x00: bytes length
-            // +0x20: depositAsset              <- read
-            // +0x40: depositAmount             <- override
-            // +0x60: minimumMint
+            // +0x20: depositAsset
+            // +0x40: depositAmount             <- override below
+            // +0x60: minimumMint               <- override below (scaled)
             // +0x80: offset to BridgeData tuple
             depositAsset := mload(add(0x20, depositAndBridgeCallData))
+            encodedDepositAmount := mload(add(0x40, depositAndBridgeCallData))
+            encodedMinimumMint := mload(add(0x60, depositAndBridgeCallData))
         }
 
         uint256 depositAmount = depositAsset.fastBalanceOf(address(this));
         depositAsset.safeApproveIfBelow(address(WPAXG), depositAmount);
 
+        // Scale `minimumMint` proportionally to the actual deposit amount. Rounding down favors
+        // the caller (smaller slippage threshold). Reverts on encoded amount of zero.
+        uint256 minimumMint = encodedMinimumMint * depositAmount / encodedDepositAmount;
+
         assembly ("memory-safe") {
             mstore(add(0x40, depositAndBridgeCallData), depositAmount)
+            mstore(add(0x60, depositAndBridgeCallData), minimumMint)
         }
         // selector for `depositAndBridge(address,uint256,uint256,(uint32,address,address,uint64,bytes))`
         _callTeller(0xbfe1a0f2, depositAndBridgeCallData);

--- a/src/core/NucleusTeller.sol
+++ b/src/core/NucleusTeller.sol
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {IERC20} from "@forge-std/interfaces/IERC20.sol";
+import {SafeTransferLib} from "../vendor/SafeTransferLib.sol";
+
+/// @dev Mirrors the relevant subset of paxoslabs/nucleus-boring-vault `CrossChainTellerBase`.
+/// `BridgeData` follows `src/interfaces/ICrossChainTypes.sol` from that repo.
+interface INucleusTeller {
+    struct BridgeData {
+        uint32 chainSelector;
+        address destinationChainReceiver;
+        IERC20 bridgeFeeToken;
+        uint64 messageGas;
+        bytes data;
+    }
+
+    function vault() external view returns (address);
+
+    function bridge(uint256 shareAmount, BridgeData calldata data) external payable returns (bytes32);
+
+    function depositAndBridge(IERC20 depositAsset, uint256 depositAmount, uint256 minimumMint, BridgeData calldata data)
+        external
+        payable;
+
+    function previewFee(uint256 shareAmount, BridgeData calldata data) external view returns (uint256);
+}
+
+/// @title NucleusTeller
+/// @notice BridgeSettler integration for Paxos Nucleus `CrossChainTellerBase` contracts (e.g. WPAXG).
+/// @dev Native bridge fees are paid from the contract's full ETH balance. Per Paxos Nucleus, any
+/// excess is consumed by the underlying messaging protocol (LayerZero) and is not refunded.
+contract NucleusTeller {
+    using SafeTransferLib for IERC20;
+
+    /// @notice Bridge BoringVault shares held by this contract via a Nucleus Teller.
+    /// @dev `bridge` burns shares from `msg.sender` (this contract) via `vault.exit(...)`, so the
+    /// shares must already be sitting here. No approval is required.
+    /// @param teller The `CrossChainTellerBase` to call
+    /// @param bridgeCallData Encoded args (no selector) to `INucleusTeller.bridge`:
+    ///        `(shareAmount, BridgeData)`. `shareAmount` is overridden with this contract's
+    ///        share balance.
+    function bridgeToNucleusTeller(address teller, bytes memory bridgeCallData) internal {
+        uint256 shareAmount = IERC20(_tellerVault(teller)).fastBalanceOf(address(this));
+
+        assembly ("memory-safe") {
+            // bridgeCallData layout in memory:
+            // +0x00: bytes length
+            // +0x20: shareAmount               <- OVERRIDE here
+            // +0x40: offset to BridgeData tuple
+            mstore(add(0x20, bridgeCallData), shareAmount)
+
+            let len := mload(bridgeCallData)
+            // Temporarily clobber the bytes length slot with the function selector
+            mstore(bridgeCallData, 0xa69559d1) // selector for `bridge(uint256,(uint32,address,address,uint64,bytes))`
+
+            // `teller` is user-provided but we're calling a specific function `bridge` which doesn't
+            // clash with restricted targets (AllowanceHolder & Permit2)
+            if iszero(call(gas(), teller, selfbalance(), add(0x1c, bridgeCallData), add(0x04, len), 0x00, 0x00)) {
+                let ptr := mload(0x40)
+                returndatacopy(ptr, 0x00, returndatasize())
+                revert(ptr, returndatasize())
+            }
+            // Restore clobbered length
+            mstore(bridgeCallData, len)
+        }
+    }
+
+    /// @notice Deposit `depositAsset` into the Nucleus BoringVault and bridge the resulting shares.
+    /// @dev `depositAndBridge` pulls `depositAsset` from `msg.sender` (this contract) into the
+    /// BoringVault, mints shares to `msg.sender`, then immediately burns and bridges them. The
+    /// BoringVault — not the Teller — needs the ERC20 approval.
+    /// @param teller The `CrossChainTellerBase` to call
+    /// @param depositAndBridgeCallData Encoded args (no selector) to `INucleusTeller.depositAndBridge`:
+    ///        `(depositAsset, depositAmount, minimumMint, BridgeData)`. `depositAmount` is
+    ///        overridden with this contract's balance of `depositAsset`.
+    function depositAndBridgeToNucleusTeller(address teller, bytes memory depositAndBridgeCallData) internal {
+        IERC20 depositAsset;
+        assembly ("memory-safe") {
+            // depositAndBridgeCallData layout in memory:
+            // +0x00: bytes length
+            // +0x20: depositAsset              <- read
+            // +0x40: depositAmount             <- OVERRIDE below
+            // +0x60: minimumMint
+            // +0x80: offset to BridgeData tuple
+            depositAsset := mload(add(0x20, depositAndBridgeCallData))
+        }
+
+        uint256 depositAmount = depositAsset.fastBalanceOf(address(this));
+        depositAsset.safeApproveIfBelow(_tellerVault(teller), depositAmount);
+
+        assembly ("memory-safe") {
+            mstore(add(0x40, depositAndBridgeCallData), depositAmount)
+
+            let len := mload(depositAndBridgeCallData)
+            mstore(depositAndBridgeCallData, 0xbfe1a0f2) // selector for `depositAndBridge(address,uint256,uint256,(uint32,address,address,uint64,bytes))`
+
+            if iszero(
+                call(gas(), teller, selfbalance(), add(0x1c, depositAndBridgeCallData), add(0x04, len), 0x00, 0x00)
+            ) {
+                let ptr := mload(0x40)
+                returndatacopy(ptr, 0x00, returndatasize())
+                revert(ptr, returndatasize())
+            }
+            mstore(depositAndBridgeCallData, len)
+        }
+    }
+
+    function _tellerVault(address teller) private view returns (address vault) {
+        assembly ("memory-safe") {
+            mstore(0x00, 0xfbfa77cf) // selector for `vault()`
+            if iszero(staticcall(gas(), teller, 0x1c, 0x04, 0x00, 0x20)) {
+                let ptr := mload(0x40)
+                returndatacopy(ptr, 0x00, returndatasize())
+                revert(ptr, returndatasize())
+            }
+            if gt(0x20, returndatasize()) { revert(0x00, 0x00) }
+            vault := mload(0x00)
+        }
+    }
+}

--- a/src/core/NucleusTeller.sol
+++ b/src/core/NucleusTeller.sol
@@ -66,9 +66,9 @@ contract NucleusTeller {
         assembly ("memory-safe") {
             // depositAndBridgeCallData layout in memory:
             // +0x00: bytes length
-            // +0x20: depositAsset
-            // +0x40: depositAmount             <- override below
-            // +0x60: minimumMint               <- override below (scaled)
+            // +0x20: depositAsset              <- read
+            // +0x40: depositAmount             <- override
+            // +0x60: minimumMint               <- override
             // +0x80: offset to BridgeData tuple
             depositAsset := mload(add(0x20, depositAndBridgeCallData))
             encodedDepositAmount := mload(add(0x40, depositAndBridgeCallData))
@@ -78,8 +78,7 @@ contract NucleusTeller {
         uint256 depositAmount = depositAsset.fastBalanceOf(address(this));
         depositAsset.safeApproveIfBelow(address(WPAXG), depositAmount);
 
-        // Scale `minimumMint` proportionally to the actual deposit amount via 512-bit intermediate
-        // to avoid overflow. Rounds down (favors the caller); reverts on encoded amount of zero.
+        // Scale `minimumMint` proportionally to the actual deposit amount.
         uint256 minimumMint = tmp().omul(encodedMinimumMint, depositAmount).div(encodedDepositAmount);
 
         assembly ("memory-safe") {

--- a/src/core/NucleusTeller.sol
+++ b/src/core/NucleusTeller.sol
@@ -35,10 +35,7 @@ interface INucleusTeller {
 
 /// @title NucleusTeller
 /// @notice BridgeSettler integration for the Paxos Nucleus WPAXG `CrossChainTellerBase`.
-/// @dev Native bridge fees are paid from the contract's full ETH balance. The underlying
-/// LayerZero endpoint refunds any excess back to this contract via the Teller's
-/// `payable(msg.sender)` refund address.
-/// The Teller and WPAXG share token addresses are identical on every chain the deployment
+/// @dev The Teller and WPAXG share token addresses are identical on every chain the deployment
 /// supports (Ethereum and Optimism), so they are hardcoded.
 contract NucleusTeller {
     using SafeTransferLib for IERC20;
@@ -50,15 +47,13 @@ contract NucleusTeller {
     IERC20 internal constant WPAXG = IERC20(0x5cB5C4d5e8B184A364534bc688DA0553Ccf8F484);
 
     /// @notice Bridge WPAXG shares held by this contract via the Nucleus Teller.
-    /// @param bridgeCallData Encoded args (no selector) to `INucleusTeller.bridge`:
-    ///        `(shareAmount, BridgeData)`. `shareAmount` is overridden with this contract's
-    ///        WPAXG balance.
+    /// @param bridgeCallData Encoded args (no selector) to `INucleusTeller.bridge`.
     function bridgeToNucleusTeller(bytes memory bridgeCallData) internal {
         uint256 shareAmount = WPAXG.fastBalanceOf(address(this));
         assembly ("memory-safe") {
             // bridgeCallData layout in memory:
             // +0x00: bytes length
-            // +0x20: shareAmount               <- OVERRIDE here
+            // +0x20: shareAmount               <- override
             // +0x40: offset to BridgeData tuple
             mstore(add(0x20, bridgeCallData), shareAmount)
         }
@@ -67,16 +62,14 @@ contract NucleusTeller {
     }
 
     /// @notice Deposit `depositAsset` into the WPAXG BoringVault and bridge the resulting shares.
-    /// @param depositAndBridgeCallData Encoded args (no selector) to `INucleusTeller.depositAndBridge`:
-    ///        `(depositAsset, depositAmount, minimumMint, BridgeData)`. `depositAmount` is
-    ///        overridden with this contract's balance of `depositAsset`.
+    /// @param depositAndBridgeCallData Encoded args (no selector) to `INucleusTeller.depositAndBridge`.
     function depositAndBridgeToNucleusTeller(bytes memory depositAndBridgeCallData) internal {
         IERC20 depositAsset;
         assembly ("memory-safe") {
             // depositAndBridgeCallData layout in memory:
             // +0x00: bytes length
             // +0x20: depositAsset              <- read
-            // +0x40: depositAmount             <- OVERRIDE below
+            // +0x40: depositAmount             <- override
             // +0x60: minimumMint
             // +0x80: offset to BridgeData tuple
             depositAsset := mload(add(0x20, depositAndBridgeCallData))
@@ -100,8 +93,7 @@ contract NucleusTeller {
             mstore(data, selector)
 
             // `NUCLEUS_TELLER` is hardcoded and doesn't clash with restricted targets (AllowanceHolder & Permit2).
-            // `selfbalance()` is safe: the underlying LayerZero endpoint refunds any excess to this
-            // contract via the Teller's `payable(msg.sender)` refund address.
+            // `selfbalance()` is safe: the underlying LayerZero endpoint refunds any excess to this contract.
             if iszero(call(gas(), NUCLEUS_TELLER, selfbalance(), add(0x1c, data), add(0x04, len), 0x00, 0x00)) {
                 let ptr := mload(0x40)
                 returndatacopy(ptr, 0x00, returndatasize())

--- a/src/core/NucleusTeller.sol
+++ b/src/core/NucleusTeller.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.25;
 
 import {IERC20} from "@forge-std/interfaces/IERC20.sol";
 import {SafeTransferLib} from "../vendor/SafeTransferLib.sol";
+import {tmp} from "../utils/512Math.sol";
 
 /// @dev Mirrors the relevant subset of the deployed Nucleus WPAXG Teller
 /// (0xeE98730AAAdA5e6e092cA69F1AC1B9B554c059dF), sourced from paxoslabs/nucleus-boring-vault at
@@ -77,9 +78,9 @@ contract NucleusTeller {
         uint256 depositAmount = depositAsset.fastBalanceOf(address(this));
         depositAsset.safeApproveIfBelow(address(WPAXG), depositAmount);
 
-        // Scale `minimumMint` proportionally to the actual deposit amount. Rounding down favors
-        // the caller (smaller slippage threshold). Reverts on encoded amount of zero.
-        uint256 minimumMint = encodedMinimumMint * depositAmount / encodedDepositAmount;
+        // Scale `minimumMint` proportionally to the actual deposit amount via 512-bit intermediate
+        // to avoid overflow. Rounds down (favors the caller); reverts on encoded amount of zero.
+        uint256 minimumMint = tmp().omul(encodedMinimumMint, depositAmount).div(encodedDepositAmount);
 
         assembly ("memory-safe") {
             mstore(add(0x40, depositAndBridgeCallData), depositAmount)

--- a/src/core/NucleusTeller.sol
+++ b/src/core/NucleusTeller.sol
@@ -15,8 +15,6 @@ interface INucleusTeller {
         bytes data;
     }
 
-    function vault() external view returns (address);
-
     function bridge(uint256 shareAmount, BridgeData calldata data) external payable returns (bytes32);
 
     function depositAndBridge(IERC20 depositAsset, uint256 depositAmount, uint256 minimumMint, BridgeData calldata data)
@@ -27,21 +25,28 @@ interface INucleusTeller {
 }
 
 /// @title NucleusTeller
-/// @notice BridgeSettler integration for Paxos Nucleus `CrossChainTellerBase` contracts (e.g. WPAXG).
+/// @notice BridgeSettler integration for the Paxos Nucleus WPAXG `CrossChainTellerBase`.
 /// @dev Native bridge fees are paid from the contract's full ETH balance. Per Paxos Nucleus, any
 /// excess is consumed by the underlying messaging protocol (LayerZero) and is not refunded.
+/// The Teller and BoringVault addresses are identical on every chain the deployment supports
+/// (Ethereum and Optimism), so they are hardcoded.
 contract NucleusTeller {
     using SafeTransferLib for IERC20;
 
-    /// @notice Bridge BoringVault shares held by this contract via a Nucleus Teller.
+    /// @notice Paxos Nucleus WPAXG `CrossChainTellerBase` (same address on Ethereum and Optimism)
+    address internal constant NUCLEUS_TELLER = 0xeE98730AAAdA5e6e092cA69F1AC1B9B554c059dF;
+
+    /// @notice Paxos Nucleus WPAXG `BoringVault` / share token (same address on Ethereum and Optimism)
+    IERC20 internal constant NUCLEUS_VAULT = IERC20(0x5cB5C4d5e8B184A364534bc688DA0553Ccf8F484);
+
+    /// @notice Bridge BoringVault shares held by this contract via the Nucleus Teller.
     /// @dev `bridge` burns shares from `msg.sender` (this contract) via `vault.exit(...)`, so the
     /// shares must already be sitting here. No approval is required.
-    /// @param teller The `CrossChainTellerBase` to call
     /// @param bridgeCallData Encoded args (no selector) to `INucleusTeller.bridge`:
     ///        `(shareAmount, BridgeData)`. `shareAmount` is overridden with this contract's
     ///        share balance.
-    function bridgeToNucleusTeller(address teller, bytes memory bridgeCallData) internal {
-        uint256 shareAmount = IERC20(_tellerVault(teller)).fastBalanceOf(address(this));
+    function bridgeToNucleusTeller(bytes memory bridgeCallData) internal {
+        uint256 shareAmount = NUCLEUS_VAULT.fastBalanceOf(address(this));
 
         assembly ("memory-safe") {
             // bridgeCallData layout in memory:
@@ -54,9 +59,10 @@ contract NucleusTeller {
             // Temporarily clobber the bytes length slot with the function selector
             mstore(bridgeCallData, 0xa69559d1) // selector for `bridge(uint256,(uint32,address,address,uint64,bytes))`
 
-            // `teller` is user-provided but we're calling a specific function `bridge` which doesn't
-            // clash with restricted targets (AllowanceHolder & Permit2)
-            if iszero(call(gas(), teller, selfbalance(), add(0x1c, bridgeCallData), add(0x04, len), 0x00, 0x00)) {
+            // The hardcoded `NUCLEUS_TELLER` cannot clash with restricted targets (AllowanceHolder & Permit2)
+            if iszero(
+                call(gas(), NUCLEUS_TELLER, selfbalance(), add(0x1c, bridgeCallData), add(0x04, len), 0x00, 0x00)
+            ) {
                 let ptr := mload(0x40)
                 returndatacopy(ptr, 0x00, returndatasize())
                 revert(ptr, returndatasize())
@@ -70,11 +76,10 @@ contract NucleusTeller {
     /// @dev `depositAndBridge` pulls `depositAsset` from `msg.sender` (this contract) into the
     /// BoringVault, mints shares to `msg.sender`, then immediately burns and bridges them. The
     /// BoringVault — not the Teller — needs the ERC20 approval.
-    /// @param teller The `CrossChainTellerBase` to call
     /// @param depositAndBridgeCallData Encoded args (no selector) to `INucleusTeller.depositAndBridge`:
     ///        `(depositAsset, depositAmount, minimumMint, BridgeData)`. `depositAmount` is
     ///        overridden with this contract's balance of `depositAsset`.
-    function depositAndBridgeToNucleusTeller(address teller, bytes memory depositAndBridgeCallData) internal {
+    function depositAndBridgeToNucleusTeller(bytes memory depositAndBridgeCallData) internal {
         IERC20 depositAsset;
         assembly ("memory-safe") {
             // depositAndBridgeCallData layout in memory:
@@ -87,7 +92,7 @@ contract NucleusTeller {
         }
 
         uint256 depositAmount = depositAsset.fastBalanceOf(address(this));
-        depositAsset.safeApproveIfBelow(_tellerVault(teller), depositAmount);
+        depositAsset.safeApproveIfBelow(address(NUCLEUS_VAULT), depositAmount);
 
         assembly ("memory-safe") {
             mstore(add(0x40, depositAndBridgeCallData), depositAmount)
@@ -96,26 +101,21 @@ contract NucleusTeller {
             mstore(depositAndBridgeCallData, 0xbfe1a0f2) // selector for `depositAndBridge(address,uint256,uint256,(uint32,address,address,uint64,bytes))`
 
             if iszero(
-                call(gas(), teller, selfbalance(), add(0x1c, depositAndBridgeCallData), add(0x04, len), 0x00, 0x00)
+                call(
+                    gas(),
+                    NUCLEUS_TELLER,
+                    selfbalance(),
+                    add(0x1c, depositAndBridgeCallData),
+                    add(0x04, len),
+                    0x00,
+                    0x00
+                )
             ) {
                 let ptr := mload(0x40)
                 returndatacopy(ptr, 0x00, returndatasize())
                 revert(ptr, returndatasize())
             }
             mstore(depositAndBridgeCallData, len)
-        }
-    }
-
-    function _tellerVault(address teller) private view returns (address vault) {
-        assembly ("memory-safe") {
-            mstore(0x00, 0xfbfa77cf) // selector for `vault()`
-            if iszero(staticcall(gas(), teller, 0x1c, 0x04, 0x00, 0x20)) {
-                let ptr := mload(0x40)
-                returndatacopy(ptr, 0x00, returndatasize())
-                revert(ptr, returndatasize())
-            }
-            if gt(0x20, returndatasize()) { revert(0x00, 0x00) }
-            vault := mload(0x00)
         }
     }
 }

--- a/src/core/NucleusTeller.sol
+++ b/src/core/NucleusTeller.sol
@@ -28,54 +28,40 @@ interface INucleusTeller {
 /// @notice BridgeSettler integration for the Paxos Nucleus WPAXG `CrossChainTellerBase`.
 /// @dev Native bridge fees are paid from the contract's full ETH balance. Per Paxos Nucleus, any
 /// excess is consumed by the underlying messaging protocol (LayerZero) and is not refunded.
-/// The Teller and BoringVault addresses are identical on every chain the deployment supports
-/// (Ethereum and Optimism), so they are hardcoded.
+/// The Teller and WPAXG share token addresses are identical on every chain the deployment
+/// supports (Ethereum and Optimism), so they are hardcoded.
 contract NucleusTeller {
     using SafeTransferLib for IERC20;
 
     /// @notice Paxos Nucleus WPAXG `CrossChainTellerBase` (same address on Ethereum and Optimism)
     address internal constant NUCLEUS_TELLER = 0xeE98730AAAdA5e6e092cA69F1AC1B9B554c059dF;
 
-    /// @notice Paxos Nucleus WPAXG `BoringVault` / share token (same address on Ethereum and Optimism)
-    IERC20 internal constant NUCLEUS_VAULT = IERC20(0x5cB5C4d5e8B184A364534bc688DA0553Ccf8F484);
+    /// @notice WPAXG share token / Nucleus `BoringVault` (same address on Ethereum and Optimism)
+    IERC20 internal constant WPAXG = IERC20(0x5cB5C4d5e8B184A364534bc688DA0553Ccf8F484);
 
-    /// @notice Bridge BoringVault shares held by this contract via the Nucleus Teller.
+    /// @notice Bridge WPAXG shares held by this contract via the Nucleus Teller.
     /// @dev `bridge` burns shares from `msg.sender` (this contract) via `vault.exit(...)`, so the
     /// shares must already be sitting here. No approval is required.
     /// @param bridgeCallData Encoded args (no selector) to `INucleusTeller.bridge`:
     ///        `(shareAmount, BridgeData)`. `shareAmount` is overridden with this contract's
-    ///        share balance.
+    ///        WPAXG balance.
     function bridgeToNucleusTeller(bytes memory bridgeCallData) internal {
-        uint256 shareAmount = NUCLEUS_VAULT.fastBalanceOf(address(this));
-
+        uint256 shareAmount = WPAXG.fastBalanceOf(address(this));
         assembly ("memory-safe") {
             // bridgeCallData layout in memory:
             // +0x00: bytes length
             // +0x20: shareAmount               <- OVERRIDE here
             // +0x40: offset to BridgeData tuple
             mstore(add(0x20, bridgeCallData), shareAmount)
-
-            let len := mload(bridgeCallData)
-            // Temporarily clobber the bytes length slot with the function selector
-            mstore(bridgeCallData, 0xa69559d1) // selector for `bridge(uint256,(uint32,address,address,uint64,bytes))`
-
-            // The hardcoded `NUCLEUS_TELLER` cannot clash with restricted targets (AllowanceHolder & Permit2)
-            if iszero(
-                call(gas(), NUCLEUS_TELLER, selfbalance(), add(0x1c, bridgeCallData), add(0x04, len), 0x00, 0x00)
-            ) {
-                let ptr := mload(0x40)
-                returndatacopy(ptr, 0x00, returndatasize())
-                revert(ptr, returndatasize())
-            }
-            // Restore clobbered length
-            mstore(bridgeCallData, len)
         }
+        // selector for `bridge(uint256,(uint32,address,address,uint64,bytes))`
+        _callTeller(0xa69559d1, bridgeCallData);
     }
 
-    /// @notice Deposit `depositAsset` into the Nucleus BoringVault and bridge the resulting shares.
+    /// @notice Deposit `depositAsset` into the WPAXG BoringVault and bridge the resulting shares.
     /// @dev `depositAndBridge` pulls `depositAsset` from `msg.sender` (this contract) into the
-    /// BoringVault, mints shares to `msg.sender`, then immediately burns and bridges them. The
-    /// BoringVault — not the Teller — needs the ERC20 approval.
+    /// BoringVault, mints shares to `msg.sender`, then immediately burns and bridges them. WPAXG
+    /// — the BoringVault, not the Teller — needs the ERC20 approval.
     /// @param depositAndBridgeCallData Encoded args (no selector) to `INucleusTeller.depositAndBridge`:
     ///        `(depositAsset, depositAmount, minimumMint, BridgeData)`. `depositAmount` is
     ///        overridden with this contract's balance of `depositAsset`.
@@ -92,30 +78,32 @@ contract NucleusTeller {
         }
 
         uint256 depositAmount = depositAsset.fastBalanceOf(address(this));
-        depositAsset.safeApproveIfBelow(address(NUCLEUS_VAULT), depositAmount);
+        depositAsset.safeApproveIfBelow(address(WPAXG), depositAmount);
 
         assembly ("memory-safe") {
             mstore(add(0x40, depositAndBridgeCallData), depositAmount)
+        }
+        // selector for `depositAndBridge(address,uint256,uint256,(uint32,address,address,uint64,bytes))`
+        _callTeller(0xbfe1a0f2, depositAndBridgeCallData);
+    }
 
-            let len := mload(depositAndBridgeCallData)
-            mstore(depositAndBridgeCallData, 0xbfe1a0f2) // selector for `depositAndBridge(address,uint256,uint256,(uint32,address,address,uint64,bytes))`
+    /// @dev Calls `NUCLEUS_TELLER` with `selector` prepended to `data`, forwarding the full ETH
+    /// balance as msg.value. Temporarily clobbers and restores the `data` length slot to avoid
+    /// allocating a new memory buffer. Bubbles up any revert data.
+    function _callTeller(uint256 selector, bytes memory data) private {
+        assembly ("memory-safe") {
+            let len := mload(data)
+            // Temporarily clobber the bytes length slot with the function selector
+            mstore(data, selector)
 
-            if iszero(
-                call(
-                    gas(),
-                    NUCLEUS_TELLER,
-                    selfbalance(),
-                    add(0x1c, depositAndBridgeCallData),
-                    add(0x04, len),
-                    0x00,
-                    0x00
-                )
-            ) {
+            // The hardcoded `NUCLEUS_TELLER` cannot clash with restricted targets (AllowanceHolder & Permit2)
+            if iszero(call(gas(), NUCLEUS_TELLER, selfbalance(), add(0x1c, data), add(0x04, len), 0x00, 0x00)) {
                 let ptr := mload(0x40)
                 returndatacopy(ptr, 0x00, returndatasize())
                 revert(ptr, returndatasize())
             }
-            mstore(depositAndBridgeCallData, len)
+            // Restore clobbered length
+            mstore(data, len)
         }
     }
 }

--- a/test/integration/NucleusTeller.t.sol
+++ b/test/integration/NucleusTeller.t.sol
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {IERC20} from "@forge-std/interfaces/IERC20.sol";
+import {ISignatureTransfer} from "@permit2/interfaces/ISignatureTransfer.sol";
+import {BridgeSettlerIntegrationTest} from "./BridgeSettler.t.sol";
+import {ALLOWANCE_HOLDER} from "src/allowanceholder/IAllowanceHolder.sol";
+import {IBridgeSettlerActions} from "src/bridge/IBridgeSettlerActions.sol";
+import {INucleusTeller} from "src/core/NucleusTeller.sol";
+import {SafeTransferLib} from "src/vendor/SafeTransferLib.sol";
+import {ActionDataBuilder} from "../utils/ActionDataBuilder.sol";
+import {LibBytes} from "../utils/LibBytes.sol";
+
+contract NucleusTellerMainnetTest is BridgeSettlerIntegrationTest {
+    using SafeTransferLib for IERC20;
+    using LibBytes for bytes;
+
+    // WPAXG Teller (Paxos Nucleus CrossChainTellerBase) and BoringVault (= WPAXG share token) on Ethereum mainnet
+    address constant TELLER = 0xeE98730AAAdA5e6e092cA69F1AC1B9B554c059dF;
+    IERC20 constant WPAXG = IERC20(0x5cB5C4d5e8B184A364534bc688DA0553Ccf8F484);
+    IERC20 constant PAXG = IERC20(0x45804880De22913dAFE09f4980848ECE6EcbAf78);
+
+    // LayerZero v2 endpoint ID for Optimism (destination chain)
+    uint32 constant OP_LZ_EID = 30111;
+
+    address recipient;
+
+    receive() external payable {}
+
+    function _testBlockNumber() internal pure override returns (uint256) {
+        // Recent mainnet block where the WPAXG Teller and BoringVault are deployed.
+        return 24700000;
+    }
+
+    function setUp() public override {
+        super.setUp();
+        vm.label(TELLER, "WPAXG_Teller");
+        vm.label(address(WPAXG), "WPAXG");
+        vm.label(address(PAXG), "PAXG");
+        recipient = makeAddr("recipient");
+    }
+
+    function _bridgeData() internal view returns (INucleusTeller.BridgeData memory) {
+        return INucleusTeller.BridgeData({
+            chainSelector: OP_LZ_EID,
+            destinationChainReceiver: recipient,
+            bridgeFeeToken: IERC20(address(0)),
+            messageGas: 200_000,
+            data: bytes("")
+        });
+    }
+
+    function testBridge_WPAXG_to_OP() public {
+        uint256 shareAmount = 1e18;
+
+        // Fund this contract with WPAXG and approve AllowanceHolder so BridgeSettler can pull them in
+        deal(address(WPAXG), address(this), shareAmount, true);
+        WPAXG.safeApprove(address(ALLOWANCE_HOLDER), shareAmount);
+
+        INucleusTeller.BridgeData memory data = _bridgeData();
+        uint256 fee = INucleusTeller(TELLER).previewFee(shareAmount, data);
+
+        // The action overrides shareAmount with the BridgeSettler's balance; encode a 0 placeholder
+        bytes memory bridgeCallData = abi.encodeCall(INucleusTeller.bridge, (0, data)).popSelector();
+
+        bytes[] memory actions = ActionDataBuilder.build(
+            _getDefaultTransferFrom(address(WPAXG), shareAmount),
+            abi.encodeCall(IBridgeSettlerActions.BRIDGE_TO_NUCLEUS_TELLER, (TELLER, bridgeCallData))
+        );
+
+        deal(address(this), fee);
+        uint256 supplyBefore = WPAXG.totalSupply();
+
+        vm.expectCall(TELLER, fee, abi.encodeCall(INucleusTeller.bridge, (shareAmount, data)));
+        ALLOWANCE_HOLDER.exec{value: fee}(
+            address(bridgeSettler),
+            address(WPAXG),
+            shareAmount,
+            payable(address(bridgeSettler)),
+            abi.encodeCall(bridgeSettler.execute, (actions, bytes32(0)))
+        );
+
+        assertEq(WPAXG.balanceOf(address(bridgeSettler)), 0, "BridgeSettler should hold no WPAXG after bridge");
+        assertEq(WPAXG.totalSupply(), supplyBefore - shareAmount, "Shares should have been burned");
+        assertEq(address(bridgeSettler).balance, 0, "BridgeSettler should have forwarded the full fee");
+    }
+
+    function testDepositAndBridge_PAXG_to_OP() public {
+        uint256 depositAmount = 1e18;
+
+        // Fund this contract with PAXG and approve AllowanceHolder
+        deal(address(PAXG), address(this), depositAmount, true);
+        PAXG.safeApprove(address(ALLOWANCE_HOLDER), depositAmount);
+
+        INucleusTeller.BridgeData memory data = _bridgeData();
+        // previewFee takes shares, not deposit amount. We compute expected shares from the
+        // BoringVault accountant rate, mirroring `_erc20Deposit`. For the test purpose, we
+        // simply use the deposit amount as a fee preview proxy — actual conversion is done by
+        // the Teller via the accountant.
+        uint256 expectedShares = depositAmount; // 1:1 placeholder for fee preview
+        uint256 fee = INucleusTeller(TELLER).previewFee(expectedShares, data);
+
+        // depositAmount field is overridden by the action; encode 0 placeholder
+        bytes memory depositAndBridgeCallData =
+            abi.encodeCall(INucleusTeller.depositAndBridge, (PAXG, 0, 0, data)).popSelector();
+
+        bytes[] memory actions = ActionDataBuilder.build(
+            _getDefaultTransferFrom(address(PAXG), depositAmount),
+            abi.encodeCall(
+                IBridgeSettlerActions.DEPOSIT_AND_BRIDGE_TO_NUCLEUS_TELLER, (TELLER, depositAndBridgeCallData)
+            )
+        );
+
+        deal(address(this), fee);
+
+        vm.expectCall(TELLER, fee, abi.encodeCall(INucleusTeller.depositAndBridge, (PAXG, depositAmount, 0, data)));
+        ALLOWANCE_HOLDER.exec{value: fee}(
+            address(bridgeSettler),
+            address(PAXG),
+            depositAmount,
+            payable(address(bridgeSettler)),
+            abi.encodeCall(bridgeSettler.execute, (actions, bytes32(0)))
+        );
+
+        assertEq(PAXG.balanceOf(address(bridgeSettler)), 0, "BridgeSettler should hold no PAXG after");
+        assertEq(WPAXG.balanceOf(address(bridgeSettler)), 0, "BridgeSettler should hold no WPAXG after bridge");
+        assertEq(address(bridgeSettler).balance, 0, "BridgeSettler should have forwarded the full fee");
+    }
+}

--- a/test/integration/NucleusTeller.t.sol
+++ b/test/integration/NucleusTeller.t.sol
@@ -153,9 +153,10 @@ contract NucleusTellerMainnetTest is BridgeSettlerIntegrationTest {
         uint256 expectedShares = depositAmount;
         uint256 fee = INucleusTeller(TELLER).previewFee(expectedShares, data);
 
-        // depositAmount field is overridden by the action; encode 0 placeholder
+        // `depositAmount` and `minimumMint` are rewritten by the action (the latter scaled by the
+        // depositAmount delta); encode the API-previewed values here.
         bytes memory depositAndBridgeCallData =
-            abi.encodeCall(INucleusTeller.depositAndBridge, (PAXG, 0, 0, data)).popSelector();
+            abi.encodeCall(INucleusTeller.depositAndBridge, (PAXG, depositAmount, expectedShares, data)).popSelector();
 
         bytes[] memory actions = ActionDataBuilder.build(
             _getDefaultTransferFrom(address(PAXG), depositAmount),
@@ -164,7 +165,10 @@ contract NucleusTellerMainnetTest is BridgeSettlerIntegrationTest {
 
         deal(address(this), fee);
 
-        vm.expectCall(TELLER, fee, abi.encodeCall(INucleusTeller.depositAndBridge, (PAXG, depositAmount, 0, data)));
+        // Runtime balance equals the encoded amount, so the scaled `minimumMint` equals `expectedShares`.
+        vm.expectCall(
+            TELLER, fee, abi.encodeCall(INucleusTeller.depositAndBridge, (PAXG, depositAmount, expectedShares, data))
+        );
         vm.recordLogs();
         ALLOWANCE_HOLDER.exec{value: fee}(
             address(bridgeSettler),

--- a/test/integration/NucleusTeller.t.sol
+++ b/test/integration/NucleusTeller.t.sol
@@ -153,10 +153,10 @@ contract NucleusTellerMainnetTest is BridgeSettlerIntegrationTest {
         uint256 expectedShares = depositAmount;
         uint256 fee = INucleusTeller(TELLER).previewFee(expectedShares, data);
 
-        // Encode `(2, 1)` — the action should scale `minimumMint` to `depositAmount / 2`,
-        // preserving the 1:2 ratio of accepted shares to deposit asset.
+        // `depositAmount` is rewritten by the action; `minimumMint` passes through as a strict
+        // slippage check. Encode `0` for the placeholder and the API-previewed shares for the latter.
         bytes memory depositAndBridgeCallData =
-            abi.encodeCall(INucleusTeller.depositAndBridge, (PAXG, 2, 1, data)).popSelector();
+            abi.encodeCall(INucleusTeller.depositAndBridge, (PAXG, 0, expectedShares, data)).popSelector();
 
         bytes[] memory actions = ActionDataBuilder.build(
             _getDefaultTransferFrom(address(PAXG), depositAmount),
@@ -166,7 +166,7 @@ contract NucleusTellerMainnetTest is BridgeSettlerIntegrationTest {
         deal(address(this), fee);
 
         vm.expectCall(
-            TELLER, fee, abi.encodeCall(INucleusTeller.depositAndBridge, (PAXG, depositAmount, depositAmount / 2, data))
+            TELLER, fee, abi.encodeCall(INucleusTeller.depositAndBridge, (PAXG, depositAmount, expectedShares, data))
         );
         vm.recordLogs();
         ALLOWANCE_HOLDER.exec{value: fee}(

--- a/test/integration/NucleusTeller.t.sol
+++ b/test/integration/NucleusTeller.t.sol
@@ -43,12 +43,15 @@ contract NucleusTellerMainnetTest is BridgeSettlerIntegrationTest {
         recipient = makeAddr("recipient");
     }
 
+    // The Teller hardcodes `NATIVE = 0xEeee...EEeE` as the only allowed bridgeFeeToken.
+    IERC20 constant ETH_PLACEHOLDER = IERC20(0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE);
+
     function _bridgeData() internal view returns (INucleusTeller.BridgeData memory) {
         return INucleusTeller.BridgeData({
             chainSelector: OP_LZ_EID,
             destinationChainReceiver: recipient,
-            bridgeFeeToken: IERC20(address(0)),
-            messageGas: 200_000,
+            bridgeFeeToken: ETH_PLACEHOLDER,
+            messageGas: 100_000,
             data: bytes("")
         });
     }

--- a/test/integration/NucleusTeller.t.sol
+++ b/test/integration/NucleusTeller.t.sol
@@ -153,10 +153,10 @@ contract NucleusTellerMainnetTest is BridgeSettlerIntegrationTest {
         uint256 expectedShares = depositAmount;
         uint256 fee = INucleusTeller(TELLER).previewFee(expectedShares, data);
 
-        // `depositAmount` and `minimumMint` are rewritten by the action (the latter scaled by the
-        // depositAmount delta); encode the API-previewed values here.
+        // Encode `(2, 1)` — the action should scale `minimumMint` to `depositAmount / 2`,
+        // preserving the 1:2 ratio of accepted shares to deposit asset.
         bytes memory depositAndBridgeCallData =
-            abi.encodeCall(INucleusTeller.depositAndBridge, (PAXG, depositAmount, expectedShares, data)).popSelector();
+            abi.encodeCall(INucleusTeller.depositAndBridge, (PAXG, 2, 1, data)).popSelector();
 
         bytes[] memory actions = ActionDataBuilder.build(
             _getDefaultTransferFrom(address(PAXG), depositAmount),
@@ -165,9 +165,8 @@ contract NucleusTellerMainnetTest is BridgeSettlerIntegrationTest {
 
         deal(address(this), fee);
 
-        // Runtime balance equals the encoded amount, so the scaled `minimumMint` equals `expectedShares`.
         vm.expectCall(
-            TELLER, fee, abi.encodeCall(INucleusTeller.depositAndBridge, (PAXG, depositAmount, expectedShares, data))
+            TELLER, fee, abi.encodeCall(INucleusTeller.depositAndBridge, (PAXG, depositAmount, depositAmount / 2, data))
         );
         vm.recordLogs();
         ALLOWANCE_HOLDER.exec{value: fee}(

--- a/test/integration/NucleusTeller.t.sol
+++ b/test/integration/NucleusTeller.t.sol
@@ -9,7 +9,6 @@ import {ALLOWANCE_HOLDER} from "src/allowanceholder/IAllowanceHolder.sol";
 import {IBridgeSettlerActions} from "src/bridge/IBridgeSettlerActions.sol";
 import {INucleusTeller} from "src/core/NucleusTeller.sol";
 import {SafeTransferLib} from "src/vendor/SafeTransferLib.sol";
-import {FullMath} from "@uniswapv4/libraries/FullMath.sol";
 import {ActionDataBuilder} from "../utils/ActionDataBuilder.sol";
 import {LibBytes} from "../utils/LibBytes.sol";
 
@@ -53,14 +52,6 @@ contract NucleusTellerMainnetTest is BridgeSettlerIntegrationTest {
             messageGas: 200_000,
             data: bytes("")
         });
-    }
-
-    /// @dev Mirrors Teller._erc20Deposit:
-    ///   shares = depositAmount.mulDivDown(ONE_SHARE, accountant.getRateInQuoteSafe(depositAsset))
-    function _quoteShares(IERC20 depositAsset, uint256 depositAmount) internal view returns (uint256) {
-        uint256 oneShare = 10 ** uint256(WPAXG.decimals());
-        uint256 rate = INucleusTeller(TELLER).accountant().getRateInQuoteSafe(depositAsset);
-        return FullMath.mulDiv(depositAmount, oneShare, rate);
     }
 
     /// @dev Asserts exactly one `MessageSent(bytes32,uint256,address)` was emitted by the Teller
@@ -157,7 +148,8 @@ contract NucleusTellerMainnetTest is BridgeSettlerIntegrationTest {
         PAXG.safeApprove(address(ALLOWANCE_HOLDER), depositAmount);
 
         INucleusTeller.BridgeData memory data = _bridgeData();
-        uint256 expectedShares = _quoteShares(PAXG, depositAmount);
+        // PAXG → WPAXG is a 1:1 wrap, so the resulting share count equals the deposit amount.
+        uint256 expectedShares = depositAmount;
         uint256 fee = INucleusTeller(TELLER).previewFee(expectedShares, data);
 
         // depositAmount field is overridden by the action; encode 0 placeholder

--- a/test/integration/NucleusTeller.t.sol
+++ b/test/integration/NucleusTeller.t.sol
@@ -15,7 +15,7 @@ contract NucleusTellerMainnetTest is BridgeSettlerIntegrationTest {
     using SafeTransferLib for IERC20;
     using LibBytes for bytes;
 
-    // WPAXG Teller (Paxos Nucleus CrossChainTellerBase) and BoringVault (= WPAXG share token) on Ethereum mainnet
+    // Hardcoded in NucleusTeller.sol — same address on every supported chain
     address constant TELLER = 0xeE98730AAAdA5e6e092cA69F1AC1B9B554c059dF;
     IERC20 constant WPAXG = IERC20(0x5cB5C4d5e8B184A364534bc688DA0553Ccf8F484);
     IERC20 constant PAXG = IERC20(0x45804880De22913dAFE09f4980848ECE6EcbAf78);
@@ -65,7 +65,7 @@ contract NucleusTellerMainnetTest is BridgeSettlerIntegrationTest {
 
         bytes[] memory actions = ActionDataBuilder.build(
             _getDefaultTransferFrom(address(WPAXG), shareAmount),
-            abi.encodeCall(IBridgeSettlerActions.BRIDGE_TO_NUCLEUS_TELLER, (TELLER, bridgeCallData))
+            abi.encodeCall(IBridgeSettlerActions.BRIDGE_TO_NUCLEUS_TELLER, (bridgeCallData))
         );
 
         deal(address(this), fee);
@@ -106,9 +106,7 @@ contract NucleusTellerMainnetTest is BridgeSettlerIntegrationTest {
 
         bytes[] memory actions = ActionDataBuilder.build(
             _getDefaultTransferFrom(address(PAXG), depositAmount),
-            abi.encodeCall(
-                IBridgeSettlerActions.DEPOSIT_AND_BRIDGE_TO_NUCLEUS_TELLER, (TELLER, depositAndBridgeCallData)
-            )
+            abi.encodeCall(IBridgeSettlerActions.DEPOSIT_AND_BRIDGE_TO_NUCLEUS_TELLER, (depositAndBridgeCallData))
         );
 
         deal(address(this), fee);

--- a/test/integration/NucleusTeller.t.sol
+++ b/test/integration/NucleusTeller.t.sol
@@ -27,6 +27,8 @@ contract NucleusTellerMainnetTest is BridgeSettlerIntegrationTest {
     // event MessageSent(bytes32 messageId, uint256 shareAmount, address to)
     bytes32 constant MESSAGE_SENT_TOPIC = 0xe0ec62d39b054dc2fd626dbc271483735df6e6fa1ef8389754bf8ab27a75eab2;
 
+    IERC20 constant ETH_ADDRESS = IERC20(0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE);
+
     address recipient;
 
     receive() external payable {}
@@ -43,14 +45,11 @@ contract NucleusTellerMainnetTest is BridgeSettlerIntegrationTest {
         recipient = makeAddr("recipient");
     }
 
-    // The Teller hardcodes `NATIVE = 0xEeee...EEeE` as the only allowed bridgeFeeToken.
-    IERC20 constant ETH_PLACEHOLDER = IERC20(0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE);
-
     function _bridgeData() internal view returns (INucleusTeller.BridgeData memory) {
         return INucleusTeller.BridgeData({
             chainSelector: OP_LZ_EID,
             destinationChainReceiver: recipient,
-            bridgeFeeToken: ETH_PLACEHOLDER,
+            bridgeFeeToken: ETH_ADDRESS,
             messageGas: 100_000,
             data: bytes("")
         });

--- a/test/integration/NucleusTeller.t.sol
+++ b/test/integration/NucleusTeller.t.sol
@@ -9,17 +9,9 @@ import {ALLOWANCE_HOLDER} from "src/allowanceholder/IAllowanceHolder.sol";
 import {IBridgeSettlerActions} from "src/bridge/IBridgeSettlerActions.sol";
 import {INucleusTeller} from "src/core/NucleusTeller.sol";
 import {SafeTransferLib} from "src/vendor/SafeTransferLib.sol";
+import {FullMath} from "@uniswapv4/libraries/FullMath.sol";
 import {ActionDataBuilder} from "../utils/ActionDataBuilder.sol";
 import {LibBytes} from "../utils/LibBytes.sol";
-
-interface INucleusAccountant {
-    function getRateInQuoteSafe(IERC20 quote) external view returns (uint256);
-}
-
-interface INucleusTellerExt {
-    function accountant() external view returns (INucleusAccountant);
-    function vault() external view returns (IERC20);
-}
 
 contract NucleusTellerMainnetTest is BridgeSettlerIntegrationTest {
     using SafeTransferLib for IERC20;
@@ -67,8 +59,8 @@ contract NucleusTellerMainnetTest is BridgeSettlerIntegrationTest {
     ///   shares = depositAmount.mulDivDown(ONE_SHARE, accountant.getRateInQuoteSafe(depositAsset))
     function _quoteShares(IERC20 depositAsset, uint256 depositAmount) internal view returns (uint256) {
         uint256 oneShare = 10 ** uint256(WPAXG.decimals());
-        uint256 rate = INucleusTellerExt(TELLER).accountant().getRateInQuoteSafe(depositAsset);
-        return (depositAmount * oneShare) / rate;
+        uint256 rate = INucleusTeller(TELLER).accountant().getRateInQuoteSafe(depositAsset);
+        return FullMath.mulDiv(depositAmount, oneShare, rate);
     }
 
     /// @dev Asserts exactly one `MessageSent(bytes32,uint256,address)` was emitted by the Teller

--- a/test/integration/NucleusTeller.t.sol
+++ b/test/integration/NucleusTeller.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.25;
 
 import {IERC20} from "@forge-std/interfaces/IERC20.sol";
+import {Vm} from "@forge-std/Vm.sol";
 import {ISignatureTransfer} from "@permit2/interfaces/ISignatureTransfer.sol";
 import {BridgeSettlerIntegrationTest} from "./BridgeSettler.t.sol";
 import {ALLOWANCE_HOLDER} from "src/allowanceholder/IAllowanceHolder.sol";
@@ -10,6 +11,15 @@ import {INucleusTeller} from "src/core/NucleusTeller.sol";
 import {SafeTransferLib} from "src/vendor/SafeTransferLib.sol";
 import {ActionDataBuilder} from "../utils/ActionDataBuilder.sol";
 import {LibBytes} from "../utils/LibBytes.sol";
+
+interface INucleusAccountant {
+    function getRateInQuoteSafe(IERC20 quote) external view returns (uint256);
+}
+
+interface INucleusTellerExt {
+    function accountant() external view returns (INucleusAccountant);
+    function vault() external view returns (IERC20);
+}
 
 contract NucleusTellerMainnetTest is BridgeSettlerIntegrationTest {
     using SafeTransferLib for IERC20;
@@ -20,8 +30,11 @@ contract NucleusTellerMainnetTest is BridgeSettlerIntegrationTest {
     IERC20 constant WPAXG = IERC20(0x5cB5C4d5e8B184A364534bc688DA0553Ccf8F484);
     IERC20 constant PAXG = IERC20(0x45804880De22913dAFE09f4980848ECE6EcbAf78);
 
-    // LayerZero v2 endpoint ID for Optimism (destination chain)
+    // LayerZero v2 endpoint IDs (https://docs.layerzero.network/v2/deployments/deployed-contracts)
     uint32 constant OP_LZ_EID = 30111;
+
+    // event MessageSent(bytes32 messageId, uint256 shareAmount, address to)
+    bytes32 constant MESSAGE_SENT_TOPIC = 0xe0ec62d39b054dc2fd626dbc271483735df6e6fa1ef8389754bf8ab27a75eab2;
 
     address recipient;
 
@@ -34,7 +47,7 @@ contract NucleusTellerMainnetTest is BridgeSettlerIntegrationTest {
 
     function setUp() public override {
         super.setUp();
-        vm.label(TELLER, "WPAXG_Teller");
+        vm.label(TELLER, "Teller");
         vm.label(address(WPAXG), "WPAXG");
         vm.label(address(PAXG), "PAXG");
         recipient = makeAddr("recipient");
@@ -50,10 +63,34 @@ contract NucleusTellerMainnetTest is BridgeSettlerIntegrationTest {
         });
     }
 
+    /// @dev Mirrors Teller._erc20Deposit:
+    ///   shares = depositAmount.mulDivDown(ONE_SHARE, accountant.getRateInQuoteSafe(depositAsset))
+    function _quoteShares(IERC20 depositAsset, uint256 depositAmount) internal view returns (uint256) {
+        uint256 oneShare = 10 ** uint256(WPAXG.decimals());
+        uint256 rate = INucleusTellerExt(TELLER).accountant().getRateInQuoteSafe(depositAsset);
+        return (depositAmount * oneShare) / rate;
+    }
+
+    /// @dev Asserts exactly one `MessageSent(bytes32,uint256,address)` was emitted by the Teller
+    /// with the given `shareAmount` and `to` fields. The `messageId` (LayerZero GUID) is unknown
+    /// up front, so we decode the data manually rather than using `vm.expectEmit`.
+    function _assertMessageSent(uint256 expectedShareAmount, address expectedTo) internal {
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        uint256 matched;
+        for (uint256 i = 0; i < logs.length; i++) {
+            if (logs[i].topics[0] == MESSAGE_SENT_TOPIC && logs[i].emitter == TELLER) {
+                (, uint256 shareAmount, address to) = abi.decode(logs[i].data, (bytes32, uint256, address));
+                assertEq(shareAmount, expectedShareAmount, "MessageSent shareAmount mismatch");
+                assertEq(to, expectedTo, "MessageSent destinationChainReceiver mismatch");
+                matched++;
+            }
+        }
+        assertEq(matched, 1, "Teller MessageSent event not emitted exactly once");
+    }
+
     function testBridge_WPAXG_to_OP() public {
         uint256 shareAmount = 1e18;
 
-        // Fund this contract with WPAXG and approve AllowanceHolder so BridgeSettler can pull them in
         deal(address(WPAXG), address(this), shareAmount, true);
         WPAXG.safeApprove(address(ALLOWANCE_HOLDER), shareAmount);
 
@@ -72,6 +109,7 @@ contract NucleusTellerMainnetTest is BridgeSettlerIntegrationTest {
         uint256 supplyBefore = WPAXG.totalSupply();
 
         vm.expectCall(TELLER, fee, abi.encodeCall(INucleusTeller.bridge, (shareAmount, data)));
+        vm.recordLogs();
         ALLOWANCE_HOLDER.exec{value: fee}(
             address(bridgeSettler),
             address(WPAXG),
@@ -80,6 +118,7 @@ contract NucleusTellerMainnetTest is BridgeSettlerIntegrationTest {
             abi.encodeCall(bridgeSettler.execute, (actions, bytes32(0)))
         );
 
+        _assertMessageSent(shareAmount, recipient);
         assertEq(WPAXG.balanceOf(address(bridgeSettler)), 0, "BridgeSettler should hold no WPAXG after bridge");
         assertEq(WPAXG.totalSupply(), supplyBefore - shareAmount, "Shares should have been burned");
         assertEq(address(bridgeSettler).balance, 0, "BridgeSettler should have forwarded the full fee");
@@ -104,6 +143,7 @@ contract NucleusTellerMainnetTest is BridgeSettlerIntegrationTest {
         deal(address(this), fee + excess);
         uint256 supplyBefore = WPAXG.totalSupply();
 
+        vm.recordLogs();
         ALLOWANCE_HOLDER.exec{value: fee + excess}(
             address(bridgeSettler),
             address(WPAXG),
@@ -112,6 +152,7 @@ contract NucleusTellerMainnetTest is BridgeSettlerIntegrationTest {
             abi.encodeCall(bridgeSettler.execute, (actions, bytes32(0)))
         );
 
+        _assertMessageSent(shareAmount, recipient);
         assertEq(WPAXG.totalSupply(), supplyBefore - shareAmount, "Bridge should have completed");
         // LayerZero refunds excess to the Teller's `payable(msg.sender)` — i.e. BridgeSettler.
         assertEq(address(bridgeSettler).balance, excess, "Excess should be refunded back to BridgeSettler");
@@ -120,16 +161,11 @@ contract NucleusTellerMainnetTest is BridgeSettlerIntegrationTest {
     function testDepositAndBridge_PAXG_to_OP() public {
         uint256 depositAmount = 1e18;
 
-        // Fund this contract with PAXG and approve AllowanceHolder
         deal(address(PAXG), address(this), depositAmount, true);
         PAXG.safeApprove(address(ALLOWANCE_HOLDER), depositAmount);
 
         INucleusTeller.BridgeData memory data = _bridgeData();
-        // previewFee takes shares, not deposit amount. We compute expected shares from the
-        // BoringVault accountant rate, mirroring `_erc20Deposit`. For the test purpose, we
-        // simply use the deposit amount as a fee preview proxy — actual conversion is done by
-        // the Teller via the accountant.
-        uint256 expectedShares = depositAmount; // 1:1 placeholder for fee preview
+        uint256 expectedShares = _quoteShares(PAXG, depositAmount);
         uint256 fee = INucleusTeller(TELLER).previewFee(expectedShares, data);
 
         // depositAmount field is overridden by the action; encode 0 placeholder
@@ -144,6 +180,7 @@ contract NucleusTellerMainnetTest is BridgeSettlerIntegrationTest {
         deal(address(this), fee);
 
         vm.expectCall(TELLER, fee, abi.encodeCall(INucleusTeller.depositAndBridge, (PAXG, depositAmount, 0, data)));
+        vm.recordLogs();
         ALLOWANCE_HOLDER.exec{value: fee}(
             address(bridgeSettler),
             address(PAXG),
@@ -152,6 +189,7 @@ contract NucleusTellerMainnetTest is BridgeSettlerIntegrationTest {
             abi.encodeCall(bridgeSettler.execute, (actions, bytes32(0)))
         );
 
+        _assertMessageSent(expectedShares, recipient);
         assertEq(PAXG.balanceOf(address(bridgeSettler)), 0, "BridgeSettler should hold no PAXG after");
         assertEq(WPAXG.balanceOf(address(bridgeSettler)), 0, "BridgeSettler should hold no WPAXG after bridge");
         assertEq(address(bridgeSettler).balance, 0, "BridgeSettler should have forwarded the full fee");

--- a/test/integration/NucleusTeller.t.sol
+++ b/test/integration/NucleusTeller.t.sol
@@ -85,6 +85,38 @@ contract NucleusTellerMainnetTest is BridgeSettlerIntegrationTest {
         assertEq(address(bridgeSettler).balance, 0, "BridgeSettler should have forwarded the full fee");
     }
 
+    function testBridge_WPAXG_to_OP_refundsExcessFee() public {
+        uint256 shareAmount = 1e18;
+
+        deal(address(WPAXG), address(this), shareAmount, true);
+        WPAXG.safeApprove(address(ALLOWANCE_HOLDER), shareAmount);
+
+        INucleusTeller.BridgeData memory data = _bridgeData();
+        uint256 fee = INucleusTeller(TELLER).previewFee(shareAmount, data);
+        uint256 excess = 0.1 ether;
+
+        bytes memory bridgeCallData = abi.encodeCall(INucleusTeller.bridge, (0, data)).popSelector();
+        bytes[] memory actions = ActionDataBuilder.build(
+            _getDefaultTransferFrom(address(WPAXG), shareAmount),
+            abi.encodeCall(IBridgeSettlerActions.BRIDGE_TO_NUCLEUS_TELLER, (bridgeCallData))
+        );
+
+        deal(address(this), fee + excess);
+        uint256 supplyBefore = WPAXG.totalSupply();
+
+        ALLOWANCE_HOLDER.exec{value: fee + excess}(
+            address(bridgeSettler),
+            address(WPAXG),
+            shareAmount,
+            payable(address(bridgeSettler)),
+            abi.encodeCall(bridgeSettler.execute, (actions, bytes32(0)))
+        );
+
+        assertEq(WPAXG.totalSupply(), supplyBefore - shareAmount, "Bridge should have completed");
+        // LayerZero refunds excess to the Teller's `payable(msg.sender)` — i.e. BridgeSettler.
+        assertEq(address(bridgeSettler).balance, excess, "Excess should be refunded back to BridgeSettler");
+    }
+
     function testDepositAndBridge_PAXG_to_OP() public {
         uint256 depositAmount = 1e18;
 

--- a/test/integration/NucleusTeller.t.sol
+++ b/test/integration/NucleusTeller.t.sol
@@ -32,8 +32,7 @@ contract NucleusTellerMainnetTest is BridgeSettlerIntegrationTest {
     receive() external payable {}
 
     function _testBlockNumber() internal pure override returns (uint256) {
-        // Recent mainnet block where the WPAXG Teller and BoringVault are deployed.
-        return 24700000;
+        return 25180132;
     }
 
     function setUp() public override {


### PR DESCRIPTION
## Summary

Adds support for bridging WPAXG (Paxos Nucleus wrapped gold) through the Nucleus Teller contract via LayerZero v2. Includes two new bridge actions: `BRIDGE_TO_NUCLEUS_TELLER` for direct WPAXG bridging and `DEPOSIT_AND_BRIDGE_TO_NUCLEUS_TELLER` for wrapping PAXG into WPAXG before bridging.

## Key Changes

- **New `NucleusTeller` core mixin** (`src/core/NucleusTeller.sol`):
  - `bridgeToNucleusTeller()`: Bridges WPAXG shares held by the settler
  - `depositAndBridgeToNucleusTeller()`: Deposits PAXG, wraps to WPAXG, and bridges resulting shares
  - `_callTeller()`: Low-level assembly helper that forwards the settler's full ETH balance as bridge fees and handles LayerZero refunds
  - Dynamically overrides `shareAmount` and `depositAmount` parameters in calldata to use the settler's actual token balances

- **Updated bridge settler implementations**:
  - `MainnetBridgeSettler` and `OptimismBridgeSettler` now inherit from `NucleusTeller`
  - Added action dispatch handlers for both new bridge actions

- **Extended `IBridgeSettlerActions` interface**:
  - Added `BRIDGE_TO_NUCLEUS_TELLER` and `DEPOSIT_AND_BRIDGE_TO_NUCLEUS_TELLER` action selectors

- **Comprehensive integration tests** (`test/integration/NucleusTeller.t.sol`):
  - `testBridge_WPAXG_to_OP()`: Verifies WPAXG bridging with correct fee forwarding and share burning
  - `testBridge_WPAXG_to_OP_refundsExcessFee()`: Validates LayerZero fee refund handling
  - `testDepositAndBridge_PAXG_to_OP()`: Tests PAXG deposit, wrapping, and bridging flow

## Implementation Details

- Nucleus Teller address (`0xeE98730AAAdA5e6e092cA69F1AC1B9B554c059dF`) and WPAXG token address are hardcoded as they are identical across all supported chains
- Assembly-based calldata manipulation efficiently overrides amount parameters without full re-encoding
- Full ETH balance forwarding to Teller enables LayerZero to refund excess fees back to the settler
- Tests use fork testing at mainnet block 25180132 where both Teller and BoringVault are deployed

https://claude.ai/code/session_016x6xL6LehzfZsydng4KyHJ