### PR TITLE
Renegade v2 integration

### DIFF
--- a/src/ISettlerActions.sol
+++ b/src/ISettlerActions.sol
@@ -276,8 +276,7 @@ interface ISettlerActions {
         uint256 amountOutMin
     ) external;
 
-    function RENEGADE(address target, address sellToken, bool baseForQuote, bytes memory data, uint256 minBuyAmount)
-        external;
+    function RENEGADE(address target, address sellToken, bytes memory data, uint256 minBuyAmount) external;
 
     struct BebopMakerSignature {
         bytes signatureBytes;

--- a/src/chains/Arbitrum/Common.sol
+++ b/src/chains/Arbitrum/Common.sol
@@ -12,7 +12,7 @@ import {UniswapV4} from "../../core/UniswapV4.sol";
 import {IPoolManager} from "../../core/UniswapV4Types.sol";
 import {BalancerV3} from "../../core/BalancerV3.sol";
 import {FreeMemory} from "../../utils/FreeMemory.sol";
-import {Renegade, ARBITRUM_SELECTOR} from "../../core/Renegade.sol";
+import {Renegade} from "../../core/Renegade.sol";
 import {Bebop} from "../../core/Bebop.sol";
 
 import {ISettlerActions} from "../../ISettlerActions.sol";
@@ -134,10 +134,10 @@ abstract contract ArbitrumMixin is
 
             sellToDodoV1(sellToken, bps, dodo, quoteForBase, minBuyAmount);
         } else if (action == uint32(ISettlerActions.RENEGADE.selector)) {
-            (address target, IERC20 sellToken, bool baseForQuote, bytes memory renegadeData, uint256 minBuyAmount) =
-                abi.decode(data, (address, IERC20, bool, bytes, uint256));
+            (address target, IERC20 sellToken, bytes memory renegadeData, uint256 minBuyAmount) =
+                abi.decode(data, (address, IERC20, bytes, uint256));
 
-            sellToRenegade(target, sellToken, baseForQuote, renegadeData, minBuyAmount);
+            sellToRenegade(target, sellToken, renegadeData, minBuyAmount);
         } else {
             return false;
         }
@@ -191,10 +191,6 @@ abstract contract ArbitrumMixin is
 
     function _POOL_MANAGER() internal pure override returns (IPoolManager) {
         return ARBITRUM_POOL_MANAGER;
-    }
-
-    function _renegadeSelector() internal pure override returns (uint32) {
-        return ARBITRUM_SELECTOR;
     }
 
     // I hate Solidity inheritance

--- a/src/chains/Base/Common.sol
+++ b/src/chains/Base/Common.sol
@@ -11,7 +11,7 @@ import {IPoolManager} from "../../core/UniswapV4Types.sol";
 import {EulerSwap, IEVC, IEulerSwap} from "../../core/EulerSwap.sol";
 import {BalancerV3} from "../../core/BalancerV3.sol";
 import {PancakeInfinity} from "../../core/PancakeInfinity.sol";
-import {Renegade, BASE_SELECTOR} from "../../core/Renegade.sol";
+import {Renegade} from "../../core/Renegade.sol";
 import {Bebop} from "../../core/Bebop.sol";
 import {Hanji} from "../../core/Hanji.sol";
 
@@ -145,10 +145,10 @@ abstract contract BaseMixin is
 
             sellToDodoV2(recipient, sellToken, bps, dodo, quoteForBase, minBuyAmount);
         } else if (action == uint32(ISettlerActions.RENEGADE.selector)) {
-            (address target, IERC20 sellToken, bool baseForQuote, bytes memory renegadeData, uint256 minBuyAmount) =
-                abi.decode(data, (address, IERC20, bool, bytes, uint256));
+            (address target, IERC20 sellToken, bytes memory renegadeData, uint256 minBuyAmount) =
+                abi.decode(data, (address, IERC20, bytes, uint256));
 
-            sellToRenegade(target, sellToken, baseForQuote, renegadeData, minBuyAmount);
+            sellToRenegade(target, sellToken, renegadeData, minBuyAmount);
         } else if (action == uint32(ISettlerActions.HANJI.selector)) {
             (
                 IERC20 sellToken,
@@ -255,10 +255,6 @@ abstract contract BaseMixin is
             mstore(returndata, 0x20)
             mstore(add(0x20, returndata), shr(0x60, msgSenderShifted))
         }
-    }
-
-    function _renegadeSelector() internal pure override returns (uint32) {
-        return BASE_SELECTOR;
     }
 
     // I hate Solidity inheritance

--- a/src/core/Renegade.sol
+++ b/src/core/Renegade.sol
@@ -3,112 +3,147 @@ pragma solidity ^0.8.25;
 
 import {IERC20} from "@forge-std/interfaces/IERC20.sol";
 import {SettlerSwapAbstract} from "../SettlerAbstract.sol";
-import {revertTooMuchSlippage} from "./SettlerErrors.sol";
 import {SafeTransferLib} from "../vendor/SafeTransferLib.sol";
-import {UnsafeMath} from "../utils/UnsafeMath.sol";
-
-// selector for `sponsorMalleableAtomicMatchSettleWithRefundOptions(uint256,uint256,address,bytes,bytes,bytes,bytes,address,uint256,bool,uint256,bytes)`
-uint32 constant ARBITRUM_SELECTOR = 0x0f977971;
-// selector for `sponsorMalleableAtomicMatchSettle(uint256,uint256,address,(((uint256,uint256,uint256)),(uint256,uint256,uint256)),((address,address,(uint256),uint256,uint256,uint8),((uint256),(uint256)),((uint256),(uint256)),uint256[],address),(((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256),((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256),((uint256,uint256)[5],(uint256,uint256),(uint256,uint256)[5],(uint256,uint256),(uint256,uint256),uint256[5],uint256[4],uint256)),(((uint256,uint256),(uint256,uint256)),((uint256,uint256),(uint256,uint256))),address,bool,uint256,uint256,bytes)`
-uint32 constant BASE_SELECTOR = 0x322ef840;
 
 abstract contract Renegade is SettlerSwapAbstract {
     using SafeTransferLib for IERC20;
-    using UnsafeMath for uint256;
 
-    constructor() {
-        uint32 selector = _renegadeSelector();
-        assert(
-            (block.chainid == 42161 && selector == ARBITRUM_SELECTOR)
-                || (block.chainid == 8453 && selector == BASE_SELECTOR) || block.chainid == 31337
-        );
+    /*
+     * Memory layout of `data` (the args to `sponsorExternalMatch`, sans the
+     * 4-byte selector). The first 32 bytes are the bytes-length word; the
+     * payload begins at `data + 0x20`. Offsets below are relative to `data`
+     * itself, matching the `mload(add(data, OFFSET))` reads in this file.
+     *
+     *   sponsorExternalMatch(
+     *     0x20   uint256   sellTokenAmt
+     *     0x40   address   recipient
+     *     0x60   address   internalPartyInputToken    \
+     *     0x80   address   internalPartyOutputToken    | BoundedMatchResult
+     *     0xa0   uint256   price.repr (FixedPoint)     | (inlined static struct,
+     *     0xc0   uint256   minInternalPartyAmountIn    |  six 32-byte words)
+     *     0xe0   uint256   maxInternalPartyAmountIn    |
+     *     0x100  uint256   blockDeadline              /
+     *     0x120  uint256   <offset>  SettlementBundle: (bool isFirstFill, uint8 bundleType, bytes data)
+     *     0x140  uint256   <offset>  GasSponsorOptions: (address refundAddress, bool refundNativeEth, uint256 refundAmount, uint256 nonce, bytes signature)
+     *   )
+     */
+    uint32 public constant selector = uint32(
+        bytes4(
+            keccak256(
+                "sponsorExternalMatch(uint256,address,(address,address,(uint256),uint256,uint256,uint256),(bool,uint8,bytes),(address,bool,uint256,uint256,bytes))"
+            )
+        )
+    );
+
+    /// @notice The expected `GasSponsorV2` proxy address for the current chain.
+    /// @dev Adding a new chain requires a source change + redeploy of this contract.
+    function _renegadeGasSponsorV2() internal view returns (address) {
+        uint256 chainId = block.chainid;
+        if (chainId == 42161) return 0xcE7a8D45daa9a5B29f6d255552F577d53fF9EBcf; // Arbitrum One
+        if (chainId == 8453)  return 0xD9E0507D706408D0f14E22e50880189Fd915be80; // Base mainnet
+        revert("Renegade: unsupported chain");
     }
 
-    function _renegadeSelector() internal pure virtual returns (uint32);
-
-    /// @dev Extracts buyToken (quoteMint or baseMint) from GasSponsor calldata.
-    /// Base: standard ABI encoding; quoteMint @ data+0x1080, baseMint @ data+0x10a0.
-    /// Arbitrum: packed 20-byte addresses in statement blob; offset pointer @ data+0xa0.
-    /// baseForQuote=true -> buyToken=quoteMint, else baseMint.
-    function _extractBuyToken(bytes memory data, bool baseForQuote) internal pure returns (IERC20 buyToken) {
-        uint256 selector = _renegadeSelector();
-        assembly ("memory-safe") {
-            switch selector
-            case 0x322ef840 {
-                // Base: quoteMint @ data+0x1080, baseMint @ data+0x10a0
-                buyToken := mload(add(data, add(0x1080, shl(0x05, iszero(baseForQuote)))))
-            }
-            case 0x0f977971 {
-                // Arbitrum: packed 20B addrs in statement blob (offset ptr @ data+0xa0)
-                let stmtOffset := mload(add(0xa0, data))
-                buyToken := shr(0x60, mload(add(data, add(mul(0x14, iszero(baseForQuote)), add(0x40, stmtOffset)))))
-            }
-        }
-    }
-
-    /// @param baseForQuote True if selling base for quote.
+    /*
+     * @param target The `GasSponsorV2` contract address.
+     * @param sellToken The token that the taker is selling (the sell-token).
+     * @param data The ABI-encoded (sans 4-byte selector) calldata to
+     *             `sponsorExternalMatch()`
+     * @param minBuyAmt The minimum amount of the buy-token the taker must receive.
+     */
     function sellToRenegade(
         address target,
         IERC20 sellToken,
-        bool baseForQuote,
         bytes memory data,
-        uint256 minBuyAmount
-    ) internal returns (uint256 buyAmount) {
-        uint256 newSellAmount;
-        uint256 value;
-        if (sellToken == ETH_ADDRESS) {
-            value = address(this).balance;
-            newSellAmount = value;
-        } else {
-            newSellAmount = sellToken.fastBalanceOf(address(this));
-            sellToken.safeApproveIfBelow(address(target), newSellAmount);
-        }
-
-        // word 0: quoteAmount, word 1: baseAmount
-        uint256 originalQuoteAmount;
-        uint256 originalBaseAmount;
+        uint256 minBuyAmt
+    ) internal returns (uint256 buyAmt) {
+        // Extract the recipient from `data` and require that it matches address(this)
+        address recipient;
         assembly ("memory-safe") {
-            originalQuoteAmount := mload(add(0x20, data))
-            originalBaseAmount := mload(add(0x40, data))
+            recipient := mload(add(data, 0x40))
         }
+        require(recipient == address(this), "Renegade: bad recipient");
 
-        uint256 newQuoteAmount;
-        uint256 newBaseAmount;
-        if (baseForQuote) {
-            newBaseAmount = newSellAmount;
-            unchecked {
-                newQuoteAmount = (originalQuoteAmount * newBaseAmount).unsafeDiv(originalBaseAmount);
-            }
-            buyAmount = newQuoteAmount;
-        } else {
-            newQuoteAmount = newSellAmount;
-            unchecked {
-                newBaseAmount = (originalBaseAmount * newQuoteAmount).unsafeDiv(originalQuoteAmount);
-            }
-            buyAmount = newBaseAmount;
-        }
-
-        if (buyAmount < minBuyAmount) {
-            revertTooMuchSlippage(_extractBuyToken(data, baseForQuote), minBuyAmount, buyAmount);
-        }
-
-        uint32 selector = _renegadeSelector();
+        // Extract `minInternalPartyAmountIn` and `maxInternalPartyAmountIn` from `data`
+        uint256 minInternalPartyAmountIn;
+        uint256 maxInternalPartyAmountIn;
         assembly ("memory-safe") {
-            // override quoteAmount and baseAmount
-            mstore(add(0x20, data), newQuoteAmount)
-            mstore(add(0x40, data), newBaseAmount)
+            minInternalPartyAmountIn := mload(add(data, 0xc0))
+            maxInternalPartyAmountIn := mload(add(data, 0xe0))
+        }
 
+        // We need to look up the sellToken balance here because previous hops
+        // may have already swapped it, so it may be different than the amount
+        // that the user expects.
+        uint256 newSellAmt = sellToken.fastBalanceOf(address(this));
+
+        // Extract price from `data`.
+        uint256 priceRepr;
+        assembly ("memory-safe") {
+            priceRepr := mload(add(data, 0xa0))
+        }
+
+        // newBuyAmt = floor(newSellAmt / price), matching
+        // FixedPointLib.divIntegerByFixedPoint.
+        uint256 newBuyAmt = (newSellAmt << 63) / priceRepr;
+
+        // Check newBuyAmt
+        require(newBuyAmt >= minBuyAmt, "Renegade: newBuyAmt < minBuyAmt");
+        require(newBuyAmt >= minInternalPartyAmountIn, "Renegade: newBuyAmt < minInternalPartyAmountIn");
+        require(newBuyAmt <= maxInternalPartyAmountIn, "Renegade: newBuyAmt > maxInternalPartyAmountIn");
+
+        require(target == _renegadeGasSponsorV2(), "Renegade: bad target");
+
+        // Extract buyToken from `data`. From the external party's perspective
+        // the buy-side asset is `BoundedMatchResult.internalPartyInputToken`,
+        // at offset 0x60.
+        IERC20 buyToken;
+        assembly ("memory-safe") {
+            buyToken := mload(add(data, 0x60))
+        }
+
+        // Snapshot the buyToken balance before the call so we can measure the
+        // actual amount transferred after.
+        uint256 buyTokenBalanceBefore = buyToken.fastBalanceOf(address(this));
+
+        // Allow the sellToken contract to move newSellAmt tokens from this contract.
+        sellToken.safeApproveIfBelow(address(target), newSellAmt);
+
+        uint32 sel = selector;
+
+        assembly ("memory-safe") {
+            // Override sellTokenAmt in data (at position 0x20) with newSellAmt.
+            mstore(add(data, 0x20), newSellAmt)
+
+            // data[0x00..0x20) holds the length, data[0x20..) is the payload.
+            // Stash the length and overwrite the length word with the 32-byte
+            // selector. The 4-byte selector occupies the low 4 bytes of that
+            // word, so the on-the-wire calldata [selector | payload] begins at
+            // data + 0x1c (0x20 - 4).
             let len := mload(data)
-            // temporarily clobber `data` size memory area
-            mstore(data, selector)
-            // Allowed selectors don't clash with any relevant function of restricted targets so we can skip checking `target`
-            if iszero(call(gas(), target, value, add(0x1c, data), add(0x04, len), 0x00, 0x00)) {
+            mstore(data, sel)
+
+            // Invoke sponsorExternalMatch():
+            //   in     = data + 0x1c        (start of [selector | payload])
+            //   insize = 4 + len            (4-byte selector + len-byte payload)
+            //   out/outsize = 0             (returndata not consumed on success;
+            //                                on revert we copy returndata directly
+            //                                from the precompile buffer and bubble it)
+            if iszero(call(gas(), target, 0, add(0x1c, data), add(0x04, len), 0x00, 0x00)) {
                 let ptr := mload(0x40)
                 returndatacopy(ptr, 0x00, returndatasize())
                 revert(ptr, returndatasize())
             }
-            // restore clobbered memory
+
+            // Restore the length word clobbered with the selector. Required to
+            // (a) keep `data` a valid `bytes memory` for any subsequent reads, and
+            // (b) honor the memory-safe assembly contract, which forbids leaving
+            // compiler-managed slots in a corrupted state on exit.
             mstore(data, len)
         }
+
+        // Check the balance delta.
+        buyAmt = buyToken.fastBalanceOf(address(this)) - buyTokenBalanceBefore;
+        require(buyAmt >= minBuyAmt, "Renegade: delta < minBuyAmt");
     }
 }


### PR DESCRIPTION
This PR upgrades the 0x Settler integration with Renegade (https://renegade.fi) v2.

Renegade v2 is deployed to Base Mainnet and Arbitrum One. On both deployments, the function signature for settlement is the same: `sponsorExternalMatch(uint256,address,(address,address,(uint256),uint256,uint256,uint256),(bool,uint8,bytes),(address,bool,uint256,uint256,bytes))`

The adapter contract exposes `sellToRenegade()` with the following signature. Unlike the v1 adapter contract, there is no `bool baseForQuote` parameter.

```
function sellToRenegade(
    address target,
    IERC20 sellToken,
    bytes memory data,
    uint256 minBuyAmt
) internal returns (uint256 buyAmt)
```

Renegade's GasSponsorV2 proxy contract addresses are hardcoded, Settler contract will need to be upgraded if Renegade deploys to a another chain.