### PR TITLE
Make skipped test count as skipped in Foundry

### DIFF
--- a/test/integration/BasePairTest.t.sol
+++ b/test/integration/BasePairTest.t.sol
@@ -117,9 +117,8 @@ abstract contract BasePairTest is Test, GasSnapshot, Permit2Signature, MainnetDe
     }
 
     modifier skipIf(bool condition) {
-        if (!condition) {
-            _;
-        }
+        vm.skip(condition);
+        _;
     }
 
     function safeApproveIfBelow(IERC20 token, address who, address spender, uint256 _amount) internal {


### PR DESCRIPTION
## Summary

- Update the `skipIf` modifier in `test/integration/BasePairTest.t.sol` to call `vm.skip(condition)` and then continue with `_;`, so Foundry reports the test as skipped (rather than silently passing) when the condition is met.


