### PR TITLE
CI: run on master and fork/* branches; rename dcmt/* to fork/*

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -3,7 +3,7 @@ name: Integration Tests
 on:
   push:
     branches:
-      - main
+      - master
       - fork/cancun
       - fork/shanghai
   pull_request:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -3,7 +3,9 @@ name: Integration Tests
 on:
   push:
     branches:
-      - master
+      - main
+      - fork/cancun
+      - fork/shanghai
   pull_request:
 
 jobs:

--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -3,7 +3,7 @@ name: Size Limit Check
 on:
   push:
     branches:
-      - main
+      - master
       - fork/cancun
       - fork/shanghai
   pull_request:

--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -3,7 +3,9 @@ name: Size Limit Check
 on:
   push:
     branches:
-      - master
+      - main
+      - fork/cancun
+      - fork/shanghai
   pull_request:
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,9 @@ name: tests
 on:
   push:
     branches:
-      - master
+      - main
+      - fork/cancun
+      - fork/shanghai
   pull_request:
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: tests
 on:
   push:
     branches:
-      - main
+      - master
       - fork/cancun
       - fork/shanghai
   pull_request:

--- a/sh/common.sh
+++ b/sh/common.sh
@@ -60,17 +60,17 @@ function get_config {
 
 if [[ ${IGNORE_HARDFORK-no} != [Yy]es ]] ; then
     if [[ $(get_config hardfork.shanghai) != [Tt]rue ]] ; then
-        echo 'You are on the wrong branch (switch to `dcmt/london`)' >&2
+        echo 'You are on the wrong branch (switch to `fork/london`)' >&2
         exit 1
     fi
 
     if [[ $(get_config hardfork.cancun) != [Tt]rue ]] ; then
-        echo 'You are on the wrong branch (switch to `dcmt/shanghai`)' >&2
+        echo 'You are on the wrong branch (switch to `fork/shanghai`)' >&2
         exit 1
     fi
 
     if [[ $(get_config hardfork.osaka) != [Tt]rue ]] ; then
-        echo 'You are on the wrong branch (switch to `dcmt/cancun`)' >&2
+        echo 'You are on the wrong branch (switch to `fork/cancun`)' >&2
         exit 1
     fi
 fi


### PR DESCRIPTION
## Summary

- Update the push triggers in `test.yml`, `integration.yml`, and `size.yml` to run on `master`, `fork/cancun`, and `fork/shanghai` (previously only `master`).
- Rename the `dcmt/*` branch hints in `sh/common.sh` to `fork/*` so the error messages match the new branch naming convention used after this PR is merged.

## Changes

- `.github/workflows/test.yml`: `push.branches` now `[master, fork/cancun, fork/shanghai]`
- `.github/workflows/integration.yml`: same update
- `.github/workflows/size.yml`: same update
- `sh/common.sh`: `dcmt/london` → `fork/london`, `dcmt/shanghai` → `fork/shanghai`, `dcmt/cancun` → `fork/cancun`
