### PR TITLE
Add SquadSwapV3 VIP on BSC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Non-breaking changes
 
+* Add SquadSwapV3 UniV3 fork to Bnb with fork ID 38
 * Add `BRIDGE_TO_NUCLEUS_TELLER` (Mainnet and Optimism) and
   `DEPOSIT_AND_BRIDGE_TO_NUCLEUS_TELLER` (Mainnet) actions for bridging WPAXG
   through Nucleus Teller

--- a/UNISWAPV3_FORKS.md
+++ b/UNISWAPV3_FORKS.md
@@ -45,3 +45,5 @@
    36. AboreanCL
    <!-- -->
    37. Thena (Algebra-like)
+   <!-- -->
+   38. SquadSwapV3

--- a/src/chains/Bnb/Common.sol
+++ b/src/chains/Bnb/Common.sol
@@ -33,6 +33,12 @@ import {
 } from "../../core/univ3forks/PancakeSwapV3.sol";
 //import {sushiswapV3BnbFactory, sushiswapV3ForkId} from "../../core/univ3forks/SushiswapV3.sol";
 import {thenaFactory, thenaInitHash, thenaForkId} from "../../core/univ3forks/Thena.sol";
+import {
+    squadSwapV3PoolDeployer,
+    squadSwapV3InitHash,
+    squadSwapV3ForkId,
+    ISquadSwapV3Callback
+} from "../../core/univ3forks/SquadSwapV3.sol";
 import {IAlgebraCallback} from "../../core/univ3forks/Algebra.sol";
 
 import {BNB_POOL_MANAGER} from "../../core/UniswapV4Addresses.sol";
@@ -158,6 +164,10 @@ abstract contract BnbMixin is
             factory = thenaFactory;
             initHash = thenaInitHash;
             callbackSelector = uint32(IAlgebraCallback.algebraSwapCallback.selector);
+        } else if (forkId == squadSwapV3ForkId) {
+            factory = squadSwapV3PoolDeployer;
+            initHash = squadSwapV3InitHash;
+            callbackSelector = uint32(ISquadSwapV3Callback.squadV3SwapCallback.selector);
         } else {
             revertUnknownForkId(forkId);
         }

--- a/src/core/univ3forks/SquadSwapV3.sol
+++ b/src/core/univ3forks/SquadSwapV3.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+address constant squadSwapV3PoolDeployer = 0x127AA917Ace4a3880fa5E193947F2190829144A4;
+bytes32 constant squadSwapV3InitHash = 0xff132c7c84e5449c9d69fc8490aba7f25fe4033e8889a13556c416128e1308cf;
+uint8 constant squadSwapV3ForkId = 38;
+
+interface ISquadSwapV3Callback {
+    function squadV3SwapCallback(int256 amount0Delta, int256 amount1Delta, bytes calldata data) external;
+}

--- a/test/integration/SquadSwapV3.t.sol
+++ b/test/integration/SquadSwapV3.t.sol
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {IERC20} from "@forge-std/interfaces/IERC20.sol";
+import {ISignatureTransfer} from "@permit2/interfaces/ISignatureTransfer.sol";
+
+import {ActionDataBuilder} from "../utils/ActionDataBuilder.sol";
+import {Settler} from "src/Settler.sol";
+import {ISettlerActions} from "src/ISettlerActions.sol";
+import {BnbSettler} from "src/chains/Bnb/TakerSubmitted.sol";
+import {squadSwapV3ForkId} from "src/core/univ3forks/SquadSwapV3.sol";
+
+import {SettlerBasePairTest} from "./SettlerBasePairTest.t.sol";
+
+contract SquadSwapV3Test is SettlerBasePairTest {
+    IERC20 private constant USDT = IERC20(0x55d398326f99059fF775485246999027B3197955);
+    IERC20 private constant WBNB = IERC20(0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c);
+
+    function _testName() internal pure override returns (string memory) {
+        return "USDT-WBNB";
+    }
+
+    function _testChainId() internal pure override returns (string memory) {
+        return "bnb";
+    }
+
+    function _testBlockNumber() internal pure override returns (uint256) {
+        return 66500000;
+    }
+
+    function fromToken() internal pure override returns (IERC20) {
+        return USDT;
+    }
+
+    function toToken() internal pure override returns (IERC20) {
+        return WBNB;
+    }
+
+    function amount() internal pure override returns (uint256) {
+        return 100e18;
+    }
+
+    function settlerInitCode() internal pure override returns (bytes memory) {
+        return bytes.concat(type(BnbSettler).creationCode, abi.encode(bytes20(0)));
+    }
+
+    function setUp() public override {
+        super.setUp();
+
+        // FROM has code at this block; clear it across fork rolls so Permit2 uses ecrecover.
+        vm.etch(FROM, "");
+        vm.makePersistent(FROM);
+        safeApproveIfBelow(fromToken(), FROM, address(PERMIT2), amount());
+    }
+
+    function testSquadSwapV3VIP() public {
+        (ISignatureTransfer.PermitTransferFrom memory permit, bytes memory sig) = _getDefaultFromPermit2();
+        bytes[] memory actions = ActionDataBuilder.build(
+            abi.encodeCall(
+                ISettlerActions.UNISWAPV3_VIP,
+                (
+                    FROM,
+                    permit,
+                    abi.encodePacked(USDT, squadSwapV3ForkId, uint24(500), uint160(4295128740), WBNB),
+                    sig,
+                    0
+                )
+            )
+        );
+
+        vm.startPrank(FROM);
+        snapStartName("settler_squadSwapV3VIP");
+        Settler.AllowedSlippage memory slippage;
+        Settler(settler).execute(slippage, actions, bytes32(0));
+        snapEnd();
+        vm.stopPrank();
+
+        assertEq(USDT.balanceOf(FROM), 0);
+        assertGt(WBNB.balanceOf(FROM), 0);
+    }
+}


### PR DESCRIPTION
Add SquadSwapV3 on BNB, similar to Thena https://github.com/0xProject/0x-settler/pull/508

This hardcodes the new SquadSwapV3 pool deployer/init hash/callback selector so `UNISWAPV3_VIP` can support it on the next BNB Settler redeploy. Not urgent

See 0xProject/0x-labs#9945

Pool deployer: `0x127AA917Ace4a3880fa5E193947F2190829144A4` [docs](https://docs.squadswap.com/platform/developers/smart-contracts/bnb-contract)
Factory: `0x10d8612D9D8269e322AB551C18a307cB4D6BC07B` [docs](https://docs.squadswap.com/platform/developers/smart-contracts/bnb-contract)

initHash works to generate live USDT/WBNB pool via cast

deployer + initHash also match the solver config in #9945
