### PR TITLE
fix: bump github actions to node24 runtimes

### DIFF
--- a/.github/workflows/dependabot-slack-alerts.yml
+++ b/.github/workflows/dependabot-slack-alerts.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Create GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.ZEROEX_AUTOMATION_APP_ID }}
           private-key: ${{ secrets.ZEROEX_AUTOMATION_PRIVATE_KEY }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -12,12 +12,12 @@ jobs:
   integration:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Install Node.js 18.x
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v6
         with:
           node-version: 18.x
 

--- a/.github/workflows/safeguard-zksync.yml
+++ b/.github/workflows/safeguard-zksync.yml
@@ -13,7 +13,7 @@ jobs:
   safeguard-zksync:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Foundry-ZKsync
         run: |

--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -12,12 +12,12 @@ jobs:
   size-limit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Install Node.js 18.x
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v6
         with:
           node-version: 18.x
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 


### PR DESCRIPTION
GitHub is removing Node ≤20 action runtimes from Actions runners on 2026-09-16, with a forced Node 24 default starting 2026-06-16 ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). Actions updated to their Node 24 releases:

- `actions/checkout` v4 → v6
- `actions/create-github-app-token` v2 → v3
- `actions/setup-node` v1 → v6