### PR TITLE
Add Across support on Monad BridgeSettler

### DIFF
--- a/src/chains/Monad/BridgeSettler.sol
+++ b/src/chains/Monad/BridgeSettler.sol
@@ -3,8 +3,9 @@ pragma solidity =0.8.34;
 
 import {IBridgeSettlerActions} from "../../bridge/IBridgeSettlerActions.sol";
 import {BridgeSettler, BridgeSettlerBase} from "../../bridge/BridgeSettler.sol";
+import {Across} from "../../core/Across.sol";
 
-contract MonadBridgeSettler is BridgeSettler {
+contract MonadBridgeSettler is BridgeSettler, Across {
     constructor(bytes20 gitCommit) BridgeSettlerBase(gitCommit) {
         assert(block.chainid == 143 || block.chainid == 31337);
     }
@@ -16,6 +17,12 @@ contract MonadBridgeSettler is BridgeSettler {
     {
         if (super._dispatch(i, action, data)) {
             return true;
+        } else if (action == uint32(IBridgeSettlerActions.BRIDGE_ERC20_TO_ACROSS.selector)) {
+            (address spoke, bytes memory depositData) = abi.decode(data, (address, bytes));
+            bridgeERC20ToAcross(spoke, depositData);
+        } else if (action == uint32(IBridgeSettlerActions.BRIDGE_NATIVE_TO_ACROSS.selector)) {
+            (address spoke, bytes memory depositData) = abi.decode(data, (address, bytes));
+            bridgeNativeToAcross(spoke, depositData);
         } else {
             return false;
         }


### PR DESCRIPTION
Wire BRIDGE_ERC20_TO_ACROSS / BRIDGE_NATIVE_TO_ACROSS actions into the Monad BridgeSettler dispatch, mirroring the existing pattern on Base and Mainnet. Previously Monad's BridgeSettler only supported the actions provided by BridgeSettlerBase (Relay, LayerZeroOFT, CCIP), so Across deposits reverted with ActionInvalid.