### PR TITLE
Add browser wallet type for signing with foundry's --browser

### DIFF
--- a/sh/common_safe_owner.sh
+++ b/sh/common_safe_owner.sh
@@ -65,6 +65,11 @@ function sign_call {
         _sign_call_result="$(jq -Mr .result <<<"$_sign_call_result")"
     else
         _sign_call_result="$(cast wallet sign "${wallet_args[@]}" --from "$signer" --data "$_sign_call_struct_json")"
+        if [[ $wallet_type = 'browser' ]] ; then
+            # `cast wallet sign --browser` (foundry v1.5.1) prints connection
+            # status lines to stdout before the signature; keep only the last line
+            _sign_call_result="${_sign_call_result##*$'\n'}"
+        fi
     fi
     declare -r _sign_call_result
 

--- a/sh/common_wallet_type.sh
+++ b/sh/common_wallet_type.sh
@@ -40,7 +40,7 @@ case $wallet_type in
 esac
 
 if [[ $wallet_type = 'browser' ]] ; then
-    echo 'Switch your browser wallet to '"${chain_display_name:-the target chain}"' (chain ID '"${chainid:-unknown}"') before connecting.' >&2
+    echo 'Switch your browser wallet to '"${chain_display_name}"' (chain ID '"${chainid}"') before connecting.' >&2
     echo '`cast` will not switch chains for you; a mismatched chain fails the transaction or signature request.' >&2
 fi
 

--- a/sh/common_wallet_type.sh
+++ b/sh/common_wallet_type.sh
@@ -5,7 +5,7 @@ if [[ -f "$saved_wallet_type" && -r "$saved_wallet_type" ]] ; then
     wallet_type="$(<"$saved_wallet_type")"
 else
     PS3='What kind of wallet are you using? '
-    select wallet_type in ledger trezor hot frame ; do break ; done
+    select wallet_type in ledger trezor hot frame browser ; do break ; done
 
     if [[ ${wallet_type:-unset} = 'unset' ]] ; then
         exit 1
@@ -30,11 +30,19 @@ case $wallet_type in
     'frame')
         wallet_args=(--unlocked)
         ;;
+    'browser')
+        wallet_args=(--browser)
+        ;;
     *)
         echo 'Unrecognized wallet type: '"$wallet_type" >&2
         exit 1
         ;;
 esac
+
+if [[ $wallet_type = 'browser' ]] ; then
+    echo 'Switch your browser wallet to '"${chain_display_name:-the target chain}"' (chain ID '"${chainid:-unknown}"') before connecting.' >&2
+    echo '`cast` will not switch chains for you; a mismatched chain fails the transaction or signature request.' >&2
+fi
 
 if [[ $wallet_type = 'ledger' ]] ; then
     declare -r saved_wallet_ledger_path="$project_root"/config/ledger_hd_path.txt


### PR DESCRIPTION
## Description

Adds a `browser` wallet type to the deployment/governance scripts, mapping to foundry's `--browser` flag. This spins up a local signing page (default port 9545) that connects to any injected browser-extension wallet.

- `sh/common_wallet_type.sh`: adds `browser` to the wallet menu and maps it to `wallet_args=(--browser)`. Works for both `cast send` (transaction submission) and `cast wallet sign --data` (Safe EIP-712 signing) on the pinned foundry v1.5.1 — no version bump needed.
- `sh/common_safe_owner.sh`: `cast wallet sign --browser` on v1.5.1 prints connection status lines to stdout ahead of the signature (fixed upstream on master via `eprintln!`), so `sign_call` keeps only the last line of output when the wallet type is `browser`.

## Chain selection

Foundry v1.5.1 does not ask the browser wallet to switch chains; a mismatch fails the request (`cast send`) or is rejected by the wallet itself (EIP-712 signing, since the Safe domain pins `chainId`). The scripts print a reminder with the target chain name and ID before connecting. `cast send --browser` gains automatic `wallet_switchEthereumChain` once the repo adopts a foundry release containing foundry-rs/foundry#15608; typed-data signing remains a manual switch.

## Limitations

- Each `cast` invocation opens a fresh browser connection; multi-signature scripts (e.g. `confirm_new_settler.sh`) reconnect once per payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)