### PR TITLE
Read submitter address suggestion from config/submitter.txt

### DIFF
--- a/sh/abandon_chain.sh
+++ b/sh/abandon_chain.sh
@@ -144,9 +144,7 @@ echo "Will set sole owner to: $initial_owner" >&2
 
 . "$project_root"/sh/common_safe.sh
 
-declare signer
-IFS='' read -p 'What address will you submit with?: ' -e -r -i 0xEf37aD2BACD70119F141140f7B5E46Cd53a65fc4 signer
-declare -r signer
+. "$project_root"/sh/common_submitter.sh
 
 . "$project_root"/sh/common_safe_deployer.sh
 . "$project_root"/sh/common_wallet_type.sh

--- a/sh/add_signer.sh
+++ b/sh/add_signer.sh
@@ -131,9 +131,7 @@ declare -r safe_address
 
 . "$project_root"/sh/common_safe.sh
 
-declare signer
-IFS='' read -p 'What address will you submit with?: ' -e -r -i 0xEf37aD2BACD70119F141140f7B5E46Cd53a65fc4 signer
-declare -r signer
+. "$project_root"/sh/common_submitter.sh
 
 . "$project_root"/sh/common_safe_deployer.sh
 . "$project_root"/sh/common_wallet_type.sh

--- a/sh/common_submitter.sh
+++ b/sh/common_submitter.sh
@@ -1,0 +1,13 @@
+declare -r saved_submitter="$project_root"/config/submitter.txt
+
+declare suggested_submitter=0xEf37aD2BACD70119F141140f7B5E46Cd53a65fc4
+if [[ -f "$saved_submitter" && -r "$saved_submitter" ]] ; then
+    suggested_submitter="$(<"$saved_submitter")"
+fi
+declare -r suggested_submitter
+
+declare signer
+IFS='' read -p 'What address will you submit with?: ' -e -r -i "$suggested_submitter" signer
+declare -r signer
+
+echo "$signer" >"$saved_submitter"

--- a/sh/deploy_multicall.sh
+++ b/sh/deploy_multicall.sh
@@ -126,9 +126,7 @@ if [[ $(cast keccak "$(cast code --rpc-url "$rpc_url" 0x4e59b44847b379578588920c
     exit 1
 fi
 
-declare signer
-IFS='' read -p 'What address will you submit with?: ' -e -r -i 0xEf37aD2BACD70119F141140f7B5E46Cd53a65fc4 signer
-declare -r signer
+. "$project_root"/sh/common_submitter.sh
 
 . "$project_root"/sh/common_wallet_type.sh
 . "$project_root"/sh/common_gas.sh

--- a/sh/deploy_new_bridge_settler.sh
+++ b/sh/deploy_new_bridge_settler.sh
@@ -127,9 +127,7 @@ declare -r safe_address
 
 . "$project_root"/sh/common_safe.sh
 
-declare signer
-IFS='' read -p 'What address will you submit with?: ' -e -r -i 0xEf37aD2BACD70119F141140f7B5E46Cd53a65fc4 signer
-declare -r signer
+. "$project_root"/sh/common_submitter.sh
 
 . "$project_root"/sh/common_wallet_type.sh
 . "$project_root"/sh/common_safe_deployer.sh

--- a/sh/deploy_new_settler.sh
+++ b/sh/deploy_new_settler.sh
@@ -127,9 +127,7 @@ declare -r safe_address
 
 . "$project_root"/sh/common_safe.sh
 
-declare signer
-IFS='' read -p 'What address will you submit with?: ' -e -r -i 0xEf37aD2BACD70119F141140f7B5E46Cd53a65fc4 signer
-declare -r signer
+. "$project_root"/sh/common_submitter.sh
 
 . "$project_root"/sh/common_wallet_type.sh
 

--- a/sh/deploy_safeguard.sh
+++ b/sh/deploy_safeguard.sh
@@ -232,9 +232,7 @@ if [[ $(cast code --rpc-url "$rpc_url" "$factory") == '0x' ]] ; then
     exit 1
 fi
 
-declare signer
-IFS='' read -p 'What address will you submit with?: ' -e -r -i 0xEf37aD2BACD70119F141140f7B5E46Cd53a65fc4 signer
-declare -r signer
+. "$project_root"/sh/common_submitter.sh
 
 . "$project_root"/sh/common_wallet_type.sh
 . "$project_root"/sh/common_gas.sh

--- a/sh/new_feature.sh
+++ b/sh/new_feature.sh
@@ -136,9 +136,7 @@ else
 fi
 declare -r deployment_safe_address
 
-declare signer
-IFS='' read -p 'What address will you submit with?: ' -e -r -i 0xEf37aD2BACD70119F141140f7B5E46Cd53a65fc4 signer
-declare -r signer
+. "$project_root"/sh/common_submitter.sh
 
 . "$project_root"/sh/common_wallet_type.sh
 . "$project_root"/sh/common_gas.sh

--- a/sh/remove_signer.sh
+++ b/sh/remove_signer.sh
@@ -131,9 +131,7 @@ declare -r safe_address
 
 . "$project_root"/sh/common_safe.sh
 
-declare signer
-IFS='' read -p 'What address will you submit with?: ' -e -r -i 0xEf37aD2BACD70119F141140f7B5E46Cd53a65fc4 signer
-declare -r signer
+. "$project_root"/sh/common_submitter.sh
 
 . "$project_root"/sh/common_safe_deployer.sh
 . "$project_root"/sh/common_wallet_type.sh

--- a/sh/renew_authority.sh
+++ b/sh/renew_authority.sh
@@ -128,9 +128,7 @@ declare -r safe_address
 . "$project_root"/sh/common_safe.sh
 . "$project_root"/sh/common_safe_deployer.sh
 
-declare signer
-IFS='' read -p 'What address will you submit with?: ' -e -r -i 0xEf37aD2BACD70119F141140f7B5E46Cd53a65fc4 signer
-declare -r signer
+. "$project_root"/sh/common_submitter.sh
 
 . "$project_root"/sh/common_wallet_type.sh
 . "$project_root"/sh/common_gas.sh

--- a/sh/replace_signer.sh
+++ b/sh/replace_signer.sh
@@ -131,9 +131,7 @@ declare -r safe_address
 
 . "$project_root"/sh/common_safe.sh
 
-declare signer
-IFS='' read -p 'What address will you submit with?: ' -e -r -i 0xEf37aD2BACD70119F141140f7B5E46Cd53a65fc4 signer
-declare -r signer
+. "$project_root"/sh/common_submitter.sh
 
 . "$project_root"/sh/common_safe_deployer.sh
 . "$project_root"/sh/common_wallet_type.sh


### PR DESCRIPTION
## Description

The deployment and signer-rotation scripts share the `What address will you submit with?` prompt via a new helper, `sh/common_submitter.sh`:

- The suggested answer comes from `config/submitter.txt` when it exists; otherwise the default submitter address `0xEf37aD2BACD70119F141140f7B5E46Cd53a65fc4` is suggested.
- The chosen address is saved back to `config/submitter.txt`, so the next run suggests the last-used submitter.
- `config/` is gitignored, so the saved address stays local — same treatment as `config/safe_owner.txt`.

Scripts using the helper: `deploy_new_settler.sh`, `deploy_new_bridge_settler.sh`, `deploy_multicall.sh`, `deploy_safeguard.sh`, `new_feature.sh`, `add_signer.sh`, `remove_signer.sh`, `replace_signer.sh`, `renew_authority.sh`, `abandon_chain.sh`.

`deploy_safe_infra.sh` and `submit_deployer_upgrade.sh` are personal Frame-only scripts whose submitter is fixed at the `cast send` invocation with no prompt; they are intentionally out of scope.

## Gas Optimization

N/A — shell tooling only, no contract changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)