### PR TITLE
Skip size checking in CI for chains that are not in the branch

### DIFF
--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -41,6 +41,10 @@ jobs:
         run: |
           set -Eeufo pipefail -o posix
           jq -r '.[].displayName' < chain_config.json | while IFS= read -r chain ; do
+            if [[ ! -d src/chains/"$chain" ]] ; then
+              echo 'Skipping '"$chain"' (chain not present on this branch)' >&2
+              continue
+            fi
             echo 'Checking sizes for '"$chain" >&2
             forge build --sizes -- src/chains/"$chain"
           done


### PR DESCRIPTION
`fork/*` branches might have missing chains that are in the config but not in the `src/chains/*`, then, this PR tries to avoid CI failures like current one in `fork/shanghai` (https://github.com/0xProject/0x-settler/commit/495a9bf7b9a99567658b7bdde9113ace32edefb5)

We either do this or remove the chains from the config 