### PR TITLE
Add configurable positive slippage proportion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Breaking changes
 
+* `POSITIVE_SLIPPAGE` accepts a `surplusPpm` argument that controls the proportion
+  of surplus transferred
 * Update `RENEGADE` signature: replace `target` and `baseForQuote` with
   `recipient`, `buyToken`, `maxSellAmount`, `refundNativeEth`, and
   `maxRefundAmount`

--- a/src/ISettlerActions.sol
+++ b/src/ISettlerActions.sol
@@ -216,8 +216,13 @@ interface ISettlerActions {
         uint256 amountOutMin
     ) external;
 
-    function POSITIVE_SLIPPAGE(address payable recipient, address token, uint256 expectedAmount, uint256 maxPpm)
-        external;
+    function POSITIVE_SLIPPAGE(
+        address payable recipient,
+        address token,
+        uint256 expectedAmount,
+        uint256 surplusPpm,
+        uint256 maxPpm
+    ) external;
 
     /// @dev Trades against a basic AMM which follows the approval, transferFrom(msg.sender) interaction
     // Pre-req: Funded

--- a/src/SettlerBase.sol
+++ b/src/SettlerBase.sol
@@ -157,8 +157,8 @@ abstract contract SettlerBase is ISettlerBase, Basic, RfqOrderSettlement, Uniswa
 
             sellToVelodrome(recipient, ppm, pool, swapInfo, minAmountOut);
         } else if (action == uint32(ISettlerActions.POSITIVE_SLIPPAGE.selector)) {
-            (address payable recipient, IERC20 token, uint256 expectedAmount, uint256 maxPpm) =
-                abi.decode(data, (address, IERC20, uint256, uint256));
+            (address payable recipient, IERC20 token, uint256 expectedAmount, uint256 surplusPpm, uint256 maxPpm) =
+                abi.decode(data, (address, IERC20, uint256, uint256, uint256));
             bool isETH = (address(token) == Constants.ETH_ADDRESS);
             uint256 balance = isETH ? address(this).balance : token.fastBalanceOf(address(this));
             if (balance > expectedAmount) {
@@ -166,6 +166,7 @@ abstract contract SettlerBase is ISettlerBase, Basic, RfqOrderSettlement, Uniswa
                 unchecked {
                     cap = balance * maxPpm / Constants.BASIS;
                     balance -= expectedAmount;
+                    balance = balance * surplusPpm / Constants.BASIS;
                 }
                 balance = (balance > cap).ternary(cap, balance);
                 if (isETH) {

--- a/src/chains/Mainnet/Common.sol
+++ b/src/chains/Mainnet/Common.sol
@@ -110,8 +110,8 @@ abstract contract MainnetMixin is
             basicSellToPool(sellToken, ppm, pool, offset, _data);
         } /* `VELODROME` is removed */
         else if (action == uint32(ISettlerActions.POSITIVE_SLIPPAGE.selector)) {
-            (address payable recipient, IERC20 token, uint256 expectedAmount, uint256 maxPpm) =
-                abi.decode(data, (address, IERC20, uint256, uint256));
+            (address payable recipient, IERC20 token, uint256 expectedAmount, uint256 surplusPpm, uint256 maxPpm) =
+                abi.decode(data, (address, IERC20, uint256, uint256, uint256));
             bool isETH = (address(token) == Constants.ETH_ADDRESS);
             uint256 balance = isETH ? address(this).balance : token.fastBalanceOf(address(this));
             if (balance > expectedAmount) {
@@ -119,6 +119,7 @@ abstract contract MainnetMixin is
                 unchecked {
                     cap = balance * maxPpm / Constants.BASIS;
                     balance -= expectedAmount;
+                    balance = balance * surplusPpm / Constants.BASIS;
                 }
                 balance = (balance > cap).ternary(cap, balance);
                 if (isETH) {

--- a/test/unit/core/BasicUnitTest.t.sol
+++ b/test/unit/core/BasicUnitTest.t.sol
@@ -5,6 +5,9 @@ import {Basic} from "src/core/Basic.sol";
 import {Permit2PaymentTakerSubmitted} from "src/core/Permit2Payment.sol";
 import {Permit2PaymentAbstract} from "src/core/Permit2PaymentAbstract.sol";
 import {AllowanceHolderContext} from "src/allowanceholder/AllowanceHolderContext.sol";
+import {BaseSettler} from "src/chains/Base/TakerSubmitted.sol";
+import {ISettlerActions} from "src/ISettlerActions.sol";
+import {ISettlerBase} from "src/interfaces/ISettlerBase.sol";
 
 import {uint512} from "src/utils/512Math.sol";
 
@@ -12,6 +15,7 @@ import {IERC20} from "@forge-std/interfaces/IERC20.sol";
 import {Utils} from "../Utils.sol";
 
 import {Test} from "@forge-std/Test.sol";
+import {MockERC20} from "@solmate/test/utils/mocks/MockERC20.sol";
 
 contract BasicDummy is Permit2PaymentTakerSubmitted, Basic {
     function sellToPool(IERC20 sellToken, uint256 ppm, address pool, uint256 offset, bytes memory data) public {
@@ -224,5 +228,87 @@ contract BasicUnitTest is Utils, Test {
 
         vm.expectRevert();
         basic.sellToPool(IERC20(0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE), ppm, POOL, offset, data);
+    }
+}
+
+contract PositiveSlippageUnitTest is Test {
+    uint256 private constant BASIS = 1_000_000;
+    IERC20 private constant ETH_ADDRESS = IERC20(0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE);
+
+    BaseSettler private settler;
+    MockERC20 private token;
+    address payable private recipient;
+
+    function setUp() public {
+        settler = new BaseSettler(bytes20(0));
+        token = new MockERC20("Test Token", "TT", 18);
+        recipient = payable(makeAddr("recipient"));
+    }
+
+    function test_PositiveSlippage_TransfersProportionOfTokenSurplus() public {
+        _executeToken(2_000_000, 1_000_000, 250_000, BASIS);
+
+        assertEq(token.balanceOf(recipient), 250_000);
+        assertEq(token.balanceOf(address(settler)), 1_750_000);
+    }
+
+    function test_PositiveSlippage_CapsTokenTransfer() public {
+        _executeToken(2_000_000, 1_000_000, 750_000, 100_000);
+
+        assertEq(token.balanceOf(recipient), 200_000);
+        assertEq(token.balanceOf(address(settler)), 1_800_000);
+    }
+
+    function test_PositiveSlippage_DoesNotTransferWithoutSurplus() public {
+        _executeToken(1_000_000, 1_500_000, BASIS, BASIS);
+
+        assertEq(token.balanceOf(recipient), 0);
+        assertEq(token.balanceOf(address(settler)), 1_000_000);
+    }
+
+    function test_PositiveSlippage_TransfersProportionOfEthSurplus() public {
+        vm.deal(address(settler), 2_000_000);
+        _execute(ETH_ADDRESS, 1_000_000, 250_000, BASIS);
+
+        assertEq(recipient.balance, 250_000);
+        assertEq(address(settler).balance, 1_750_000);
+    }
+
+    function testFuzz_PositiveSlippage_TransfersExpectedTokenAmount(
+        uint128 balance,
+        uint128 expectedAmount,
+        uint24 surplusPpm,
+        uint24 maxPpm
+    ) public {
+        expectedAmount = uint128(bound(expectedAmount, 0, balance));
+        surplusPpm = uint24(bound(surplusPpm, 0, BASIS));
+        maxPpm = uint24(bound(maxPpm, 0, BASIS));
+
+        _executeToken(balance, expectedAmount, surplusPpm, maxPpm);
+
+        uint256 proportionalAmount = (uint256(balance) - expectedAmount) * surplusPpm / BASIS;
+        uint256 cappedAmount = uint256(balance) * maxPpm / BASIS;
+        uint256 transferredAmount = proportionalAmount < cappedAmount ? proportionalAmount : cappedAmount;
+        assertEq(token.balanceOf(recipient), transferredAmount);
+        assertEq(token.balanceOf(address(settler)), uint256(balance) - transferredAmount);
+    }
+
+    function _executeToken(uint256 balance, uint256 expectedAmount, uint256 surplusPpm, uint256 maxPpm) private {
+        token.mint(address(settler), balance);
+        _execute(IERC20(address(token)), expectedAmount, surplusPpm, maxPpm);
+    }
+
+    function _execute(IERC20 asset, uint256 expectedAmount, uint256 surplusPpm, uint256 maxPpm) private {
+        bytes[] memory actions = new bytes[](1);
+        actions[0] = abi.encodeCall(
+            ISettlerActions.POSITIVE_SLIPPAGE, (recipient, address(asset), expectedAmount, surplusPpm, maxPpm)
+        );
+        settler.execute(
+            ISettlerBase.AllowedSlippage({
+                recipient: payable(address(0)), buyToken: IERC20(address(0)), minAmountOut: 0
+            }),
+            actions,
+            bytes32(0)
+        );
     }
 }


### PR DESCRIPTION
## Summary

- add a `surplusPpm` argument to `POSITIVE_SLIPPAGE`
- transfer the lesser of the configured surplus proportion and the existing output-based cap
- cover ERC-20, native asset, cap, no-surplus, and fuzzed execution paths

## Testing

- `forge test --match-contract PositiveSlippageUnitTest`
- `FOUNDRY_SOLC_VERSION=0.8.34 forge build -- src/chains/Mainnet/TakerSubmitted.sol`
- `forge build --sizes --skip MultiCall.sol --skip CrossChainReceiverFactory.sol --skip 'test/*'`
- `npm run check_vips`
- `npm run compare_gas`

## Gas Optimization

The transfer path retains one balance read and adds one multiplication and division only when the balance exceeds the expected amount. Contract-size checks pass, and existing gas snapshots are unchanged.

Prompted by: duncancmt