### PR TITLE
fix: bound EulerSwap input limit by vault capacity

### DIFF
--- a/src/core/EulerSwap.sol
+++ b/src/core/EulerSwap.sol
@@ -659,9 +659,13 @@ library EulerSwapLib {
             }
         }
 
+        // The pool deposits the fee too, so the headroom caps the gross input.
         unchecked {
-            inLimit = (inLimitFromOutLimit < inLimit).ternary(inLimitFromOutLimit, inLimit);
-            inLimit = (inLimit * 1e18).unsafeDiv(1e18 - p.fee());
+            uint256 netHeadroom = (inLimit * (1e18 - p.fee())).unsafeDiv(1e18);
+            // Comparing net amounts keeps a saturated curve bound out of the multiplication.
+            if (inLimitFromOutLimit < netHeadroom) {
+                inLimit = (inLimitFromOutLimit * 1e18).unsafeDiv(1e18 - p.fee());
+            }
         }
     }
 
@@ -907,7 +911,7 @@ abstract contract EulerSwap is SettlerSwapAbstract {
         // EulerSwap.
         ParamsLib.Params p = pool.fastGetParams();
         (uint256 reserve0, uint256 reserve1) = pool.fastGetReserves();
-        (uint256 inLimit,) = EulerSwapLib.calcLimits(_EVC(), pool, zeroForOne, p, reserve0, reserve1);
+        (uint256 inLimit, uint256 outLimit) = EulerSwapLib.calcLimits(_EVC(), pool, zeroForOne, p, reserve0, reserve1);
 
         uint256 sellAmount;
         if (ppm != 0) {
@@ -929,6 +933,8 @@ abstract contract EulerSwap is SettlerSwapAbstract {
 
         // solve the constant function
         uint256 amountOut = EulerSwapLib.findCurvePoint(sellAmount, zeroForOne, p, reserve0, reserve1);
+        // Curve rounding can quote more than the output limit, so cap the quote.
+        amountOut = (amountOut > outLimit).ternary(outLimit, amountOut);
 
         // check slippage before swapping to save some sad-path gas
         if (amountOut < amountOutMin) {

--- a/test/integration/EulerSwap.t.sol
+++ b/test/integration/EulerSwap.t.sol
@@ -25,8 +25,14 @@ import {
 } from "src/core/EulerSwap.sol";
 
 import {AllowanceHolderPairTest} from "./AllowanceHolderPairTest.t.sol";
+import {IEulerSwapFactory} from "@eulerswap/interfaces/IEulerSwapFactory.sol";
+import {IEulerSwap as IEulerSwapV1} from "@eulerswap/interfaces/IEulerSwap.sol";
 
 IEVC constant EVC = IEVC(0x0C9a3dd6b8F28529d72d7f9cE918D493519EE383);
+
+interface IEVCOperator {
+    function setAccountOperator(address account, address operator, bool authorized) external payable;
+}
 
 abstract contract EulerSwapTest is AllowanceHolderPairTest {
     using SafeTransferLib for IERC20;
@@ -171,6 +177,62 @@ abstract contract EulerSwapTest is AllowanceHolderPairTest {
         assertGt(afterBalanceTo, beforeBalanceTo);
         uint256 afterBalanceFrom = fromToken().balanceOf(FROM);
         assertEq(afterBalanceFrom + eulerSwapAmount(), beforeBalanceFrom);
+    }
+
+    function _limits(IEulerSwap pool) private view returns (uint256 inLimit, uint256 outLimit) {
+        (uint256 reserve0, uint256 reserve1) = pool.fastGetReserves();
+        return EulerSwapLib.calcLimits(EVC, pool, true, pool.fastGetParams(), reserve0, reserve1);
+    }
+
+    function _deposit(IEVault vault, address receiver, uint256 amount) private {
+        deal(address(vault.fastAsset()), address(this), amount);
+        vault.fastAsset().safeApprove(address(vault), amount);
+        vault.deposit(amount, receiver);
+    }
+
+    function _sellAtInputLimit(IEulerSwap pool) private returns (uint256 received) {
+        (uint256 inLimit,) = _limits(pool);
+        deal(address(fromToken()), FROM, inLimit + 1);
+        (ISignatureTransfer.PermitTransferFrom memory permit, bytes memory sig) = _getDefaultFromPermit2(inLimit + 1);
+        bytes[] memory actions = ActionDataBuilder.build(
+            abi.encodeCall(ISettlerActions.TRANSFER_FROM, (address(settler), permit, sig)),
+            abi.encodeCall(ISettlerActions.EULERSWAP, (FROM, address(fromToken()), 1_000_000, address(pool), true, 0))
+        );
+        uint256 before = toToken().balanceOf(FROM);
+        vm.prank(FROM, FROM);
+        settler.execute(ISettlerBase.AllowedSlippage(payable(address(0)), IERC20(address(0)), 0), actions, bytes32(0));
+        return toToken().balanceOf(FROM) - before;
+    }
+
+    // Leave headroom for the net input, but not its fee.
+    function testEulerSwapAtSupplyCap() public skipIf(eulerSwapPool() == address(0)) setEulerSwapBlock {
+        IEulerSwap pool = IEulerSwap(eulerSwapPool());
+        ParamsLib.Params params = pool.fastGetParams();
+        (uint256 grossBound,) = _limits(pool);
+        uint256 headroom = params.vault0().fastMaxDeposit(params.eulerAccount());
+        _deposit(params.vault0(), address(this), headroom - grossBound * (1e18 - params.fee()) / 1e18);
+        assertGt(_sellAtInputLimit(pool), 0);
+    }
+
+    // At 1000:1, curve rounding quotes more than the output vault's cash.
+    function testEulerSwapAtOutputCash() public skipIf(eulerSwapPool() == address(0)) setEulerSwapBlock {
+        IEulerSwapV1.Params memory params = IEulerSwapV1(eulerSwapPool()).getParams();
+        // Enough collateral for the account to borrow the whole output cash at the skewed price.
+        _deposit(IEVault(params.vault0), params.eulerAccount, 40_000_000e6);
+        (params.priceX, params.priceY) = (1000e18, 1e18);
+        IEulerSwap pool = IEulerSwap(0xf462e46E0AF6cD3E5dD6231F5F8Fba562940A8a8);
+        vm.startPrank(params.eulerAccount);
+        IEVCOperator(address(EVC)).setAccountOperator(params.eulerAccount, eulerSwapPool(), false);
+        IEVCOperator(address(EVC)).setAccountOperator(params.eulerAccount, address(pool), true);
+        IEulerSwapFactory(0xb013be1D0D380C13B58e889f412895970A2Cf228)
+            .deployPool(
+                params,
+                IEulerSwapV1.InitialState(params.equilibriumReserve0, params.equilibriumReserve1),
+                bytes32(uint256(734)) // gives the address the hook flag bits (0x28a8) the factory requires
+            );
+        vm.stopPrank();
+        (, uint256 outLimit) = _limits(pool);
+        assertEq(_sellAtInputLimit(pool), outLimit);
     }
 
     function testSolvencyCheck() public skipIf(eulerSwapPool() == address(0)) setEulerSwapBlock {


### PR DESCRIPTION
This is something we can fix. It's minor and in the worst case leads to a reverted trade. Settler's limit for an EulerSwap fill can come out a bit higher than what the pool takes.

But also, we're not using this action at all in the solver. Should we remove it instead?
